### PR TITLE
Add global navigation bar

### DIFF
--- a/FatboysofSummerDashBoard.html
+++ b/FatboysofSummerDashBoard.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Score / Minute Chart</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
     <style>
         body, html {
             margin: 0;
@@ -21,6 +22,15 @@
     </style>
 </head>
 <body>
+    <nav class="bg-gray-800 text-white p-4">
+        <ul class="flex flex-wrap gap-4 justify-center">
+            <li><a href="TribesRivalsTeamsDashboard.html" class="hover:underline">Teams</a></li>
+            <li><a href="TribesScrimWatcher.html" class="hover:underline">Scrim Watcher</a></li>
+            <li><a href="TournamentManager.html" class="hover:underline">Tournament Manager</a></li>
+            <li><a href="TwitchFeedDisplays.html" class="hover:underline">Twitch Feeds</a></li>
+            <li><a href="FatboysofSummerDashBoard.html" class="hover:underline">Fatboys Dashboard</a></li>
+        </ul>
+    </nav>
     <canvas id="scoreChart"></canvas>
 
     <script>

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -31,6 +31,15 @@
   </style>
 </head>
 <body class="text-white">
+  <nav class="bg-gray-800 text-white p-4">
+    <ul class="flex flex-wrap gap-4 justify-center">
+      <li><a href="TribesRivalsTeamsDashboard.html" class="hover:underline">Teams</a></li>
+      <li><a href="TribesScrimWatcher.html" class="hover:underline">Scrim Watcher</a></li>
+      <li><a href="TournamentManager.html" class="hover:underline">Tournament Manager</a></li>
+      <li><a href="TwitchFeedDisplays.html" class="hover:underline">Twitch Feeds</a></li>
+      <li><a href="FatboysofSummerDashBoard.html" class="hover:underline">Fatboys Dashboard</a></li>
+    </ul>
+  </nav>
   <div id="root"></div>
   <script type="text/babel">
     const POSITIONS = ['HoF', 'LD', 'MD', 'MO', 'HO', 'LO', 'Capper'];

--- a/TribesRivalsTeamsDashboard.html
+++ b/TribesRivalsTeamsDashboard.html
@@ -58,6 +58,15 @@
     </style>
 </head>
 <body class="bg-gray-900 text-white font-sans">
+    <nav class="bg-gray-800 text-white p-4">
+        <ul class="flex flex-wrap gap-4 justify-center">
+            <li><a href="TribesRivalsTeamsDashboard.html" class="hover:underline">Teams</a></li>
+            <li><a href="TribesScrimWatcher.html" class="hover:underline">Scrim Watcher</a></li>
+            <li><a href="TournamentManager.html" class="hover:underline">Tournament Manager</a></li>
+            <li><a href="TwitchFeedDisplays.html" class="hover:underline">Twitch Feeds</a></li>
+            <li><a href="FatboysofSummerDashBoard.html" class="hover:underline">Fatboys Dashboard</a></li>
+        </ul>
+    </nav>
     <!-- Header -->
     <header class="bg-gray-800 py-6 shadow-lg">
         <div class="container mx-auto px-4 text-center">

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -50,6 +50,15 @@
     </style>
 </head>
 <body class="font-sans">
+    <nav class="bg-gray-800 text-white p-4">
+        <ul class="flex flex-wrap gap-4 justify-center">
+            <li><a href="TribesRivalsTeamsDashboard.html" class="hover:underline">Teams</a></li>
+            <li><a href="TribesScrimWatcher.html" class="hover:underline">Scrim Watcher</a></li>
+            <li><a href="TournamentManager.html" class="hover:underline">Tournament Manager</a></li>
+            <li><a href="TwitchFeedDisplays.html" class="hover:underline">Twitch Feeds</a></li>
+            <li><a href="FatboysofSummerDashBoard.html" class="hover:underline">Fatboys Dashboard</a></li>
+        </ul>
+    </nav>
     <header class="text-center py-6">
         <h1 class="text-4xl font-bold text-violet-400">Tribes Rivals Scrim Watcher</h1>
     </header>

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -294,6 +294,15 @@
   </style>
 </head>
 <body>
+  <nav class="bg-gray-800 text-white p-4">
+    <ul class="flex flex-wrap gap-4 justify-center">
+      <li><a href="TribesRivalsTeamsDashboard.html" class="hover:underline">Teams</a></li>
+      <li><a href="TribesScrimWatcher.html" class="hover:underline">Scrim Watcher</a></li>
+      <li><a href="TournamentManager.html" class="hover:underline">Tournament Manager</a></li>
+      <li><a href="TwitchFeedDisplays.html" class="hover:underline">Twitch Feeds</a></li>
+      <li><a href="FatboysofSummerDashBoard.html" class="hover:underline">Fatboys Dashboard</a></li>
+    </ul>
+  </nav>
   <div class="container">
     <header>
       <div class="form-section">


### PR DESCRIPTION
## Summary
- add Tailwind nav bar to Tribes Rivals dashboard
- show nav across Scrim Watcher, Tournament Manager and Twitch feed pages
- add nav and Tailwind to Fatboys of Summer dashboard

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6882ce1f7b60832a993249897477f7c3