### PR TITLE
Update Fatboys dashboard links

### DIFF
--- a/FatboysofSummerDashBoard.html
+++ b/FatboysofSummerDashBoard.html
@@ -29,7 +29,7 @@
                 <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
                 <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
                 <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-                <li><a href="FatboysofSummerDashBoard.html" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
+                <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
             </ul>
         </div>
     </nav>

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -38,7 +38,7 @@
         <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
         <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
         <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-        <li><a href="FatboysofSummerDashBoard.html" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
+        <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
       </ul>
     </div>
   </nav>

--- a/TribesRivalsTeamsDashboard.html
+++ b/TribesRivalsTeamsDashboard.html
@@ -65,7 +65,7 @@
                 <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
                 <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
                 <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-                <li><a href="FatboysofSummerDashBoard.html" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
+                <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
             </ul>
         </div>
 

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -57,7 +57,7 @@
                 <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
                 <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
                 <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-                <li><a href="FatboysofSummerDashBoard.html" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
+                <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
             </ul>
         </div>
     </nav>

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -301,7 +301,7 @@
         <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
         <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
         <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-        <li><a href="FatboysofSummerDashBoard.html" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
+        <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- update the Fatboys dashboard link in navigation bars

## Testing
- `grep -n "https://t24085.github.io/FatBoysofSummerDraft/dashboard" -n TribesRivalsTeamsDashboard.html`


------
https://chatgpt.com/codex/tasks/task_e_68852b45f5b0832ab2b9dacae91c4454