### PR TITLE
Add navbar to TwitchFeedMobile

### DIFF
--- a/TwitchFeedMobile.html
+++ b/TwitchFeedMobile.html
@@ -292,6 +292,17 @@
   </style>
 </head>
 <body>
+  <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
+    <div class="container mx-auto">
+      <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
+        <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
+        <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
+        <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
+        <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
+        <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
+      </ul>
+    </div>
+  </nav>
   <div class="container">
     <header>
       <div class="form-section">


### PR DESCRIPTION
## Summary
- add cross-page navigation bar to `TwitchFeedMobile.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68852dc038b0832aa40d9adbea49d617