### PR TITLE
Refactor nav into shared component

### DIFF
--- a/FatboysofSummerDashBoard.html
+++ b/FatboysofSummerDashBoard.html
@@ -22,17 +22,12 @@
     </style>
 </head>
 <body>
-    <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
-        <div class="container mx-auto">
-            <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
-                <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
-                <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
-                <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
-                <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-                <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
-            </ul>
-        </div>
-    </nav>
+    <div id="nav-placeholder"></div>
+    <script>
+        fetch("nav.html")
+            .then(res => res.text())
+            .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+    </script>
     <canvas id="scoreChart"></canvas>
 
     <script>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Open `TribesRivalsTeamsDashboard.html` in your browser to access the main dashbo
 Each team page provides roster info and may link to Twitch or YouTube streams.
 
 The project is purely static—clone or download the repository and open the HTML files locally or host them via any static file hosting service.
+## Shared Navigation
+
+The main navigation menu is stored in `nav.html`. Each page dynamically loads this file using JavaScript so the links stay consistent across the site.
+
 
 ## Credits
 

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -31,17 +31,12 @@
   </style>
 </head>
 <body class="text-white">
-  <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
-    <div class="container mx-auto">
-      <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
-        <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
-        <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
-        <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
-        <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-        <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
-      </ul>
-    </div>
-  </nav>
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch("nav.html")
+      .then(res => res.text())
+      .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+  </script>
   <div id="root"></div>
   <script type="text/babel">
     const POSITIONS = ['HoF', 'LD', 'MD', 'MO', 'HO', 'LO', 'Capper'];

--- a/TribesRivalsTeamsDashboard.html
+++ b/TribesRivalsTeamsDashboard.html
@@ -58,18 +58,12 @@
     </style>
 </head>
 <body class="bg-gray-900 text-white font-sans">
-    <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
-        <div class="container mx-auto">
-            <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
-                <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
-                <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
-                <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
-                <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-                <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
-            </ul>
-        </div>
-
-    </nav>
+    <div id="nav-placeholder"></div>
+    <script>
+        fetch("nav.html")
+            .then(res => res.text())
+            .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+    </script>
     <!-- Header -->
     <header class="bg-gray-800 py-6 shadow-lg">
         <div class="container mx-auto px-4 text-center">

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -50,17 +50,12 @@
     </style>
 </head>
 <body class="font-sans">
-    <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
-        <div class="container mx-auto">
-            <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
-                <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
-                <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
-                <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
-                <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-                <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
-            </ul>
-        </div>
-    </nav>
+    <div id="nav-placeholder"></div>
+    <script>
+        fetch("nav.html")
+            .then(res => res.text())
+            .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+    </script>
     <header class="text-center py-6">
         <h1 class="text-4xl font-bold text-violet-400">Tribes Rivals Scrim Watcher</h1>
     </header>

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -294,17 +294,12 @@
   </style>
 </head>
 <body>
-  <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
-    <div class="container mx-auto">
-      <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
-        <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
-        <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
-        <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
-        <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-        <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
-      </ul>
-    </div>
-  </nav>
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch("nav.html")
+      .then(res => res.text())
+      .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+  </script>
   <div class="container">
     <header>
       <div class="form-section">

--- a/nav.html
+++ b/nav.html
@@ -1,0 +1,11 @@
+<nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
+    <div class="container mx-auto">
+        <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
+            <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
+            <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
+            <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
+            <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
+            <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
+        </ul>
+    </div>
+</nav>


### PR DESCRIPTION
## Summary
- extract common nav bar into `nav.html`
- load the nav via JavaScript on pages that used the shared menu
- document the shared navigation component in README

## Testing
- `grep -n '<nav class="bg-gray-900' -R *.html`


------
https://chatgpt.com/codex/tasks/task_e_68852db84ed8832a9a5b87b7fb6352cd