### PR TITLE
Add Twitch OAuth login feature

### DIFF
--- a/FatboysofSummerDashBoard.html
+++ b/FatboysofSummerDashBoard.html
@@ -6,6 +6,7 @@
     <title>Score / Minute Chart</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="oauth.js"></script>
     <style>
         body, html {
             margin: 0;
@@ -26,7 +27,10 @@
     <script>
         fetch("nav.html")
             .then(res => res.text())
-            .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+            .then(html => {
+                document.getElementById("nav-placeholder").innerHTML = html;
+                if (window.twitchOAuth) twitchOAuth.updateNav();
+            });
     </script>
     <canvas id="scoreChart"></canvas>
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The project is purely static—clone or download the repository and open the HTM
 
 The main navigation menu is stored in `nav.html`. Each page dynamically loads this file using JavaScript so the links stay consistent across the site.
 
+## Twitch Authentication
+
+Certain pages include a "Sign in with Twitch" button. Logging in stores your access token in `localStorage` so the site can personalize Twitch feeds. The login uses the [Twitch OAuth implicit flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#implicit-code-flow).
+
 
 ## Credits
 

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -9,6 +9,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="oauth.js"></script>
   <style>
     body {
       background-image: url('https://github.com/T24085/images/blob/main/ss_fe25c58da0c50913fac070eea8150ee2e3cb178d.1920x1080.jpg?raw=true');
@@ -35,7 +36,10 @@
   <script>
     fetch("nav.html")
       .then(res => res.text())
-      .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+      .then(html => {
+        document.getElementById("nav-placeholder").innerHTML = html;
+        if (window.twitchOAuth) twitchOAuth.updateNav();
+      });
   </script>
   <div id="root"></div>
   <script type="text/babel">

--- a/TribesRivalsTeamsDashboard.html
+++ b/TribesRivalsTeamsDashboard.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tribes Rivals Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="oauth.js"></script>
     <style>
         body {
             background-image: url('https://github.com/T24085/images/blob/main/ss_fe25c58da0c50913fac070eea8150ee2e3cb178d.1920x1080.jpg?raw=true');
@@ -62,7 +63,10 @@
     <script>
         fetch("nav.html")
             .then(res => res.text())
-            .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+            .then(html => {
+                document.getElementById("nav-placeholder").innerHTML = html;
+                if (window.twitchOAuth) twitchOAuth.updateNav();
+            });
     </script>
     <!-- Header -->
     <header class="bg-gray-800 py-6 shadow-lg">

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tribes Rivals Scrim Watcher</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="oauth.js"></script>
     <style>
         body {
             background: linear-gradient(to right, #0f172a, #4c1d95);
@@ -54,7 +55,10 @@
     <script>
         fetch("nav.html")
             .then(res => res.text())
-            .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+            .then(html => {
+                document.getElementById("nav-placeholder").innerHTML = html;
+                if (window.twitchOAuth) twitchOAuth.updateNav();
+            });
     </script>
     <header class="text-center py-6">
         <h1 class="text-4xl font-bold text-violet-400">Tribes Rivals Scrim Watcher</h1>

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tournament Twitch Feeds Display</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="oauth.js"></script>
   <style>
     body {
       background-color: #1a202c;
@@ -298,7 +299,10 @@
   <script>
     fetch("nav.html")
       .then(res => res.text())
-      .then(html => { document.getElementById("nav-placeholder").innerHTML = html; });
+      .then(html => {
+        document.getElementById("nav-placeholder").innerHTML = html;
+        if (window.twitchOAuth) twitchOAuth.updateNav();
+      });
   </script>
   <div class="container">
     <header>

--- a/nav.html
+++ b/nav.html
@@ -7,5 +7,6 @@
             <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
             <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
         </ul>
+        <button id="twitch-login-btn" class="ml-4 bg-purple-600 text-white py-1 px-3 rounded hover:bg-purple-700"></button>
     </div>
 </nav>

--- a/oauth.js
+++ b/oauth.js
@@ -1,0 +1,66 @@
+(function(){
+  const CLIENT_ID = 'meabi1n42pccff5rz9ujpno7ky9vlt';
+  const REDIRECT_URI = 'https://t24085.github.io/ProjectTribes/TribesRivalsTeamsDashboard.html';
+  const STORAGE_KEY = 'twitch_token';
+
+  function getToken() {
+    return localStorage.getItem(STORAGE_KEY);
+  }
+
+  function setToken(token) {
+    localStorage.setItem(STORAGE_KEY, token);
+  }
+
+  function clearToken() {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  function loginWithTwitch() {
+    const scope = 'user:read:email';
+    const url =
+      'https://id.twitch.tv/oauth2/authorize' +
+      `?client_id=${CLIENT_ID}` +
+      `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+      '&response_type=token' +
+      `&scope=${encodeURIComponent(scope)}`;
+    window.location.href = url;
+  }
+
+  function logoutTwitch() {
+    clearToken();
+    location.reload();
+  }
+
+  function handleRedirect() {
+    if (window.location.hash.includes('access_token')) {
+      const params = new URLSearchParams(window.location.hash.slice(1));
+      const token = params.get('access_token');
+      if (token) {
+        setToken(token);
+        window.history.replaceState({}, document.title, window.location.pathname + window.location.search);
+      }
+    }
+  }
+
+  function updateNav() {
+    const btn = document.getElementById('twitch-login-btn');
+    if (!btn) return;
+    if (getToken()) {
+      btn.textContent = 'Sign out';
+      btn.onclick = logoutTwitch;
+    } else {
+      btn.textContent = 'Sign in with Twitch';
+      btn.onclick = loginWithTwitch;
+    }
+  }
+
+  window.twitchOAuth = {
+    login: loginWithTwitch,
+    logout: logoutTwitch,
+    getToken,
+    updateNav,
+  };
+
+  handleRedirect();
+  document.addEventListener('DOMContentLoaded', updateNav);
+})();


### PR DESCRIPTION
## Summary
- create `oauth.js` module for Twitch login
- show a sign-in/out button in the shared nav
- load `oauth.js` on dashboard, scrim watcher, feeds display, tournament manager and score pages
- invoke `twitchOAuth.updateNav()` after nav loads
- document authentication in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885301f5e40832a81588ba29699d6e7