### PR TITLE
Add followed streams hover panel

### DIFF
--- a/FatboysofSummerDashBoard.html
+++ b/FatboysofSummerDashBoard.html
@@ -29,7 +29,10 @@
             .then(res => res.text())
             .then(html => {
                 document.getElementById("nav-placeholder").innerHTML = html;
-                if (window.twitchOAuth) twitchOAuth.updateNav();
+                if (window.twitchOAuth) {
+                    twitchOAuth.updateNav();
+                    twitchOAuth.initFollowedStreamsHover();
+                }
             });
     </script>
     <canvas id="scoreChart"></canvas>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The main navigation menu is stored in `nav.html`. Each page dynamically loads th
 Certain pages include a "Sign in with Twitch" button. Logging in stores your access token in `localStorage` so the site can personalize Twitch feeds. The login uses the [Twitch OAuth implicit flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#implicit-code-flow).
 When signed in, the main dashboard shows your Twitch username and displays any live channels you follow.
 
+In the navigation bar a **Followed Streams** button now appears once you're logged in. Hovering over it slides in a panel listing your currently live followed channels.
+
 
 ## Credits
 

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -38,7 +38,10 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById("nav-placeholder").innerHTML = html;
-        if (window.twitchOAuth) twitchOAuth.updateNav();
+        if (window.twitchOAuth) {
+          twitchOAuth.updateNav();
+          twitchOAuth.initFollowedStreamsHover();
+        }
       });
   </script>
   <div id="root"></div>

--- a/TribesRivalsTeamsDashboard.html
+++ b/TribesRivalsTeamsDashboard.html
@@ -65,7 +65,10 @@
             .then(res => res.text())
             .then(html => {
                 document.getElementById("nav-placeholder").innerHTML = html;
-                if (window.twitchOAuth) twitchOAuth.updateNav();
+                if (window.twitchOAuth) {
+                    twitchOAuth.updateNav();
+                    twitchOAuth.initFollowedStreamsHover();
+                }
             });
     </script>
     <!-- Header -->

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -57,7 +57,10 @@
             .then(res => res.text())
             .then(html => {
                 document.getElementById("nav-placeholder").innerHTML = html;
-                if (window.twitchOAuth) twitchOAuth.updateNav();
+                if (window.twitchOAuth) {
+                    twitchOAuth.updateNav();
+                    twitchOAuth.initFollowedStreamsHover();
+                }
             });
     </script>
     <header class="text-center py-6">

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -301,7 +301,10 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById("nav-placeholder").innerHTML = html;
-        if (window.twitchOAuth) twitchOAuth.updateNav();
+        if (window.twitchOAuth) {
+          twitchOAuth.updateNav();
+          twitchOAuth.initFollowedStreamsHover();
+        }
       });
   </script>
   <div class="container">

--- a/nav.html
+++ b/nav.html
@@ -1,5 +1,5 @@
 <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
-    <div class="container mx-auto">
+    <div class="container mx-auto relative">
         <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
             <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
             <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
@@ -8,6 +8,13 @@
             <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
         </ul>
         <button id="twitch-login-btn" class="ml-4 bg-purple-600 text-white py-1 px-3 rounded hover:bg-purple-700"></button>
+        <button id="followed-streams-toggle" class="ml-2 bg-gray-700 text-white py-1 px-3 rounded hover:bg-gray-800">Followed Streams</button>
         <span id="twitch-user" class="ml-2 text-purple-300" style="display:none;"></span>
+        <div id="followed-streams-panel" class="followed-streams-panel hidden absolute right-0 top-full bg-gray-800 text-white p-4 w-64 max-h-80 overflow-y-auto shadow-lg"></div>
     </div>
 </nav>
+<style>
+  #followed-streams-panel { transition: transform 0.3s ease; }
+  #followed-streams-panel.hidden { transform: translateX(100%); }
+  #followed-streams-panel.visible { transform: translateX(0); }
+</style>

--- a/oauth.js
+++ b/oauth.js
@@ -53,6 +53,41 @@
     }
   }
 
+  function updateFollowedStreamsPanel() {
+    const panel = document.getElementById('followed-streams-panel');
+    if (!panel) return;
+    panel.innerHTML = 'Loading...';
+    fetchFollowedStreams().then(streams => {
+      if (!streams || streams.length === 0) {
+        panel.innerHTML = '<p class="text-sm">No followed streams live.</p>';
+        return;
+      }
+      panel.innerHTML = '';
+      streams.forEach(stream => {
+        const a = document.createElement('a');
+        a.href = `https://www.twitch.tv/${stream.user_login}`;
+        a.textContent = stream.user_name;
+        a.target = '_blank';
+        a.className = 'block hover:underline mb-2';
+        panel.appendChild(a);
+      });
+    });
+  }
+
+  function initFollowedStreamsHover() {
+    const toggle = document.getElementById('followed-streams-toggle');
+    const panel = document.getElementById('followed-streams-panel');
+    if (!toggle || !panel) return;
+
+    const show = () => panel.classList.replace('hidden', 'visible');
+    const hide = () => panel.classList.replace('visible', 'hidden');
+
+    toggle.addEventListener('mouseenter', show);
+    toggle.addEventListener('mouseleave', hide);
+    panel.addEventListener('mouseenter', show);
+    panel.addEventListener('mouseleave', hide);
+  }
+
   function loginWithTwitch() {
     const scope = 'user:read:email user:read:follows';
 
@@ -86,6 +121,7 @@
     const userSpan = document.getElementById('twitch-user');
 
     if (!btn) return;
+    const panel = document.getElementById('followed-streams-panel');
     if (getToken()) {
       btn.textContent = 'Sign out';
       btn.onclick = logoutTwitch;
@@ -97,10 +133,12 @@
           }
         });
       }
+      updateFollowedStreamsPanel();
     } else {
       btn.textContent = 'Sign in with Twitch';
       btn.onclick = loginWithTwitch;
       if (userSpan) userSpan.style.display = 'none';
+      if (panel) panel.innerHTML = '';
 
     }
   }
@@ -111,9 +149,14 @@
     getToken,
     fetchUser,
     fetchFollowedStreams,
+    updateFollowedStreamsPanel,
+    initFollowedStreamsHover,
     updateNav,
   };
 
-  handleRedirect();
-  document.addEventListener('DOMContentLoaded', updateNav);
+handleRedirect();
+document.addEventListener('DOMContentLoaded', () => {
+  updateNav();
+  initFollowedStreamsHover();
+});
 })();


### PR DESCRIPTION
## Summary
- add Followed Streams button and slide-out panel to `nav.html`
- populate panel from `oauth.js` and provide hover behavior
- load hover logic after inserting navigation markup on each page
- document new feature in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688541502ad0832aaa722a5e1cff995f