### PR TITLE
Add embedded chat to Scrim Watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a collection of static HTML pages for the community aro
 
 - **TribesRivalsTeamsDashboard.html** – Main dashboard linking to individual team pages, streaming links, and historical information.
 - **TournamentManager.html** – React-based page for managing tournaments and importing sign-up data.
-- **TribesScrimWatcher.html** – Utility for previewing scrimmage matchups and team rosters.
+- **TribesScrimWatcher.html** – Utility for previewing scrimmage matchups and team rosters. Includes a chat box powered by Twitch embeds that appears alongside the match streams.
 - **TwitchFeedDisplays.html** – Layout for watching multiple Twitch streams at once.
 - **TwitchFeedMobile.html** – Mobile-friendly version of the Twitch feeds display.
 - **FatboysofSummerDashBoard.html** – Score-per-minute chart for a draft tournament.

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -48,6 +48,71 @@
             max-height: 200px;
             margin: 0 auto;
         }
+        /* Chat Panel Styles */
+        .chat-panel {
+            position: fixed;
+            right: 0;
+            top: 0;
+            bottom: 0;
+            width: 300px;
+            background: rgba(45, 55, 72, 0.9);
+            backdrop-filter: blur(10px);
+            border-left: 1px solid rgba(255, 255, 255, 0.2);
+            display: flex;
+            flex-direction: column;
+            z-index: 20;
+            padding: 10px;
+        }
+        @supports not (backdrop-filter: blur(10px)) {
+            .chat-panel {
+                background: #2d3748;
+            }
+        }
+        .chat-panel select {
+            padding: 8px;
+            background-color: rgba(45, 55, 72, 0.8);
+            color: white;
+            border: 1px solid #4a5568;
+            border-radius: 4px;
+            margin-bottom: 10px;
+        }
+        .chat-panel iframe {
+            flex: 1;
+            border: none;
+            border-radius: 4px;
+        }
+        .chat-toggle {
+            display: none;
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            background-color: #3182ce;
+            color: white;
+            padding: 10px;
+            border-radius: 50%;
+            cursor: pointer;
+            z-index: 30;
+        }
+        .chat-toggle:hover {
+            background-color: #2b6cb0;
+        }
+        @media (max-width: 1000px) {
+            .chat-panel {
+                display: none;
+                width: 100%;
+                height: 100%;
+                position: fixed;
+                top: 0;
+                left: 0;
+                z-index: 40;
+            }
+            .chat-panel.active {
+                display: flex;
+            }
+            .chat-toggle {
+                display: block;
+            }
+        }
     </style>
 </head>
 <body class="font-sans">
@@ -71,7 +136,14 @@
     <section class="max-w-6xl mx-auto p-4">
         <div id="teamSelector" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4 mb-6 px-2"></div>
         <div id="match" class="flex flex-col md:flex-row items-start justify-center gap-6"></div>
-    </section>
+        <div class="chat-panel" id="chat-panel">
+            <select id="chat-channel-select" onchange="updateChat()">
+                <option value="">Select Channel Chat</option>
+            </select>
+            <iframe id="chat-iframe" src="https://www.twitch.tv/embed/twitch/chat?parent=t24085.github.io"></iframe>
+        </div>
+        <button class="chat-toggle" id="chat-toggle" onclick="toggleChat()">💬</button>
+      </section>
     <script>
         const teams = {
             "Avalanche": {
@@ -225,6 +297,7 @@
 
         const selector = document.getElementById('teamSelector');
         let selections = [];
+        let currentChatChannel = '';
 
         for(const team in teams){
             const btn = document.createElement('div');
@@ -273,9 +346,10 @@
             renderTeamCard(t2, matchDiv);
             document.getElementById('bg-left').style.backgroundImage = `url(${teams[t1].logo})`;
             document.getElementById('bg-right').style.backgroundImage = `url(${teams[t2].logo})`;
+            populateChatDropdown([...teams[t1].streams, ...teams[t2].streams]);
         }
 
-        function renderTeamCard(team, container){
+function renderTeamCard(team, container){
     const data = teams[team];
     const card = document.createElement('div');
     card.className = 'team-card';
@@ -297,6 +371,40 @@
     `;
     container.appendChild(card);
 }
+
+        function populateChatDropdown(streams) {
+            const select = document.getElementById('chat-channel-select');
+            select.innerHTML = '<option value="">Select Channel Chat</option>';
+            const channels = streams.map(s => {
+                const match = s.url.match(/twitch\.tv\/([^/?]+)/i);
+                return match ? match[1].toLowerCase() : null;
+            }).filter(Boolean);
+            channels.forEach(channel => {
+                const option = document.createElement('option');
+                option.value = channel;
+                option.textContent = channel;
+                select.appendChild(option);
+            });
+            select.value = channels.includes(currentChatChannel) ? currentChatChannel : (channels[0] || '');
+            updateChat();
+        }
+
+        function updateChat(){
+            const select = document.getElementById('chat-channel-select');
+            const channel = select.value;
+            const iframe = document.getElementById('chat-iframe');
+            if(channel){
+                currentChatChannel = channel;
+                iframe.src = `https://www.twitch.tv/embed/${encodeURIComponent(channel)}/chat?parent=t24085.github.io`;
+            } else {
+                iframe.src = 'about:blank';
+            }
+        }
+
+        function toggleChat(){
+            const chatPanel = document.getElementById('chat-panel');
+            chatPanel.classList.toggle('active');
+        }
 
     </script>
 </body>


### PR DESCRIPTION
## Summary
- style Scrim Watcher for an embedded chat panel
- embed a Twitch chat panel next to the match display
- populate channel list from selected team streams
- document the new chat feature in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688559194f1c832a9a021b4179a2d66c