### PR TITLE
Add embedded chat to Scrim Watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a collection of static HTML pages for the community aro
 
 - **TribesRivalsTeamsDashboard.html** – Main dashboard linking to individual team pages, streaming links, and historical information.
 - **TournamentManager.html** – React-based page for managing tournaments and importing sign-up data.
-- **TribesScrimWatcher.html** – Utility for previewing scrimmage matchups and team rosters.
+- **TribesScrimWatcher.html** – Utility for previewing scrimmage matchups and team rosters. Includes a chat box powered by Twitch embeds that appears alongside the match streams.
 - **TwitchFeedDisplays.html** – Layout for watching multiple Twitch streams at once.
 - **TwitchFeedMobile.html** – Mobile-friendly version of the Twitch feeds display.
 - **FatboysofSummerDashBoard.html** – Score-per-minute chart for a draft tournament.
@@ -25,9 +25,9 @@ The main navigation menu is stored in `nav.html`. Each page dynamically loads th
 ## Twitch Authentication
 
 Certain pages include a "Sign in with Twitch" button. Logging in stores your access token in `localStorage` so the site can personalize Twitch feeds. The login uses the [Twitch OAuth implicit flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#implicit-code-flow).
-When signed in, the main dashboard shows your Twitch username and displays any live channels you follow.
+When signed in, the main dashboard shows your Twitch username.
 
-In the navigation bar a **Followed Streams** button now appears once you're logged in. Hovering over it slides in a panel listing your currently live followed channels.
+In the navigation bar a **Followed Streams** button appears after you sign in with Twitch. Hovering over it slides in a panel listing any roster channels that are live on Twitch. Because the site queries the Twitch API using your token, being logged in is required for this list to populate.
 
 
 The teams dashboard also checks each roster's streamers against Twitch and highlights teams that are currently live.

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -48,6 +48,71 @@
             max-height: 200px;
             margin: 0 auto;
         }
+        /* Chat Panel Styles */
+        .chat-panel {
+            position: fixed;
+            right: 0;
+            top: 0;
+            bottom: 0;
+            width: 300px;
+            background: rgba(45, 55, 72, 0.9);
+            backdrop-filter: blur(10px);
+            border-left: 1px solid rgba(255, 255, 255, 0.2);
+            display: flex;
+            flex-direction: column;
+            z-index: 20;
+            padding: 10px;
+        }
+        @supports not (backdrop-filter: blur(10px)) {
+            .chat-panel {
+                background: #2d3748;
+            }
+        }
+        .chat-panel select {
+            padding: 8px;
+            background-color: rgba(45, 55, 72, 0.8);
+            color: white;
+            border: 1px solid #4a5568;
+            border-radius: 4px;
+            margin-bottom: 10px;
+        }
+        .chat-panel iframe {
+            flex: 1;
+            border: none;
+            border-radius: 4px;
+        }
+        .chat-toggle {
+            display: none;
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            background-color: #3182ce;
+            color: white;
+            padding: 10px;
+            border-radius: 50%;
+            cursor: pointer;
+            z-index: 30;
+        }
+        .chat-toggle:hover {
+            background-color: #2b6cb0;
+        }
+        @media (max-width: 1000px) {
+            .chat-panel {
+                display: none;
+                width: 100%;
+                height: 100%;
+                position: fixed;
+                top: 0;
+                left: 0;
+                z-index: 40;
+            }
+            .chat-panel.active {
+                display: flex;
+            }
+            .chat-toggle {
+                display: block;
+            }
+        }
     </style>
 </head>
 <body class="font-sans">
@@ -71,7 +136,14 @@
     <section class="max-w-6xl mx-auto p-4">
         <div id="teamSelector" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4 mb-6 px-2"></div>
         <div id="match" class="flex flex-col md:flex-row items-start justify-center gap-6"></div>
-    </section>
+        <div class="chat-panel" id="chat-panel">
+            <select id="chat-channel-select" onchange="updateChat()">
+                <option value="">Select Channel Chat</option>
+            </select>
+            <iframe id="chat-iframe" src="https://www.twitch.tv/embed/twitch/chat?parent=t24085.github.io"></iframe>
+        </div>
+        <button class="chat-toggle" id="chat-toggle" onclick="toggleChat()">💬</button>
+      </section>
     <script>
         const teams = {
             "Avalanche": {
@@ -225,6 +297,7 @@
 
         const selector = document.getElementById('teamSelector');
         let selections = [];
+        let currentChatChannel = '';
 
         for(const team in teams){
             const btn = document.createElement('div');
@@ -273,9 +346,10 @@
             renderTeamCard(t2, matchDiv);
             document.getElementById('bg-left').style.backgroundImage = `url(${teams[t1].logo})`;
             document.getElementById('bg-right').style.backgroundImage = `url(${teams[t2].logo})`;
+            populateChatDropdown([...teams[t1].streams, ...teams[t2].streams]);
         }
 
-        function renderTeamCard(team, container){
+function renderTeamCard(team, container){
     const data = teams[team];
     const card = document.createElement('div');
     card.className = 'team-card';
@@ -297,6 +371,40 @@
     `;
     container.appendChild(card);
 }
+
+        function populateChatDropdown(streams) {
+            const select = document.getElementById('chat-channel-select');
+            select.innerHTML = '<option value="">Select Channel Chat</option>';
+            const channels = streams.map(s => {
+                const match = s.url.match(/twitch\.tv\/([^/?]+)/i);
+                return match ? match[1].toLowerCase() : null;
+            }).filter(Boolean);
+            channels.forEach(channel => {
+                const option = document.createElement('option');
+                option.value = channel;
+                option.textContent = channel;
+                select.appendChild(option);
+            });
+            select.value = channels.includes(currentChatChannel) ? currentChatChannel : (channels[0] || '');
+            updateChat();
+        }
+
+        function updateChat(){
+            const select = document.getElementById('chat-channel-select');
+            const channel = select.value;
+            const iframe = document.getElementById('chat-iframe');
+            if(channel){
+                currentChatChannel = channel;
+                iframe.src = `https://www.twitch.tv/embed/${encodeURIComponent(channel)}/chat?parent=t24085.github.io`;
+            } else {
+                iframe.src = 'about:blank';
+            }
+        }
+
+        function toggleChat(){
+            const chatPanel = document.getElementById('chat-panel');
+            chatPanel.classList.toggle('active');
+        }
 
     </script>
 </body>

--- a/nav.html
+++ b/nav.html
@@ -17,4 +17,18 @@
   #followed-streams-panel { transition: transform 0.3s ease; }
   #followed-streams-panel.hidden { transform: translateX(100%); }
   #followed-streams-panel.visible { transform: translateX(0); }
+  .live-box {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    background-color: #4a5568;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    margin-bottom: 0.5rem;
+  }
+  .live-dot {
+    color: #48bb78;
+    font-size: 1rem;
+    line-height: 1;
+  }
 </style>

--- a/oauth.js
+++ b/oauth.js
@@ -3,6 +3,73 @@
   const REDIRECT_URI = 'https://t24085.github.io/ProjectTribes/TribesRivalsTeamsDashboard.html';
   const STORAGE_KEY = 'twitch_token';
 
+  const TEAM_STREAMS = {
+    'Avalanche': [
+      { name: 'Wriggles', url: 'https://www.twitch.tv/wrigglespk' },
+      { name: 'TritiumJones', url: 'https://www.twitch.tv/tritiumjones' },
+      { name: 'Dean', url: 'https://www.twitch.tv/wholuvsdean' },
+      { name: 'PROJ', url: 'https://www.twitch.tv/prj_tv' },
+      { name: 'Ggglygy', url: 'https://www.twitch.tv/ggglygy' },
+      { name: 'BakaToma', url: 'https://www.twitch.tv/bakatoma1' }
+    ],
+    'ePidemic': [
+      { name: 'Kenxai', url: 'https://www.twitch.tv/kenxai' },
+      { name: 'Makasuro', url: 'https://www.twitch.tv/makasuro' }
+    ],
+    'DPRK': [
+      { name: 'CheezeCaek', url: 'https://www.twitch.tv/cheezecaek' },
+      { name: 'silynn', url: 'https://www.twitch.tv/cheddox' },
+      { name: 'ColonelFatso', url: 'https://www.twitch.tv/colonelfatso' },
+      { name: 'Pandora', url: 'https://www.twitch.tv/pandoracast' },
+      { name: 'Nemesis', url: 'https://www.twitch.tv/seansguitarworldbang' }
+    ],
+    'Zen': [
+      { name: 'Mikesters', url: 'https://www.twitch.tv/mikesters17' },
+      { name: 'Nikebeamz', url: 'https://www.twitch.tv/nikebeamz' }
+    ],
+    'TXM': [
+      { name: 'Prizzo', url: 'https://www.twitch.tv/prizzo4real' },
+      { name: 'OperationCats', url: 'https://www.twitch.tv/operationcats' },
+      { name: 'Goshawk', url: 'https://www.twitch.tv/g0shawk' },
+      { name: 'Visis', url: 'https://www.twitch.tv/visisgaming' },
+      { name: 'Cryof', url: 'https://www.twitch.tv/cryofzshooter' },
+      { name: 'Jive', url: 'https://www.twitch.tv/heavenlyjive' },
+      { name: 'freefood', url: 'https://www.twitch.tv/freefoodd' },
+      { name: 'Howsya', url: 'https://www.twitch.tv/howsya' }
+    ],
+    'FPS': [
+      { name: 'SulliedSoc', url: 'https://www.twitch.tv/SulliedSoc' },
+      { name: 'Beldark', url: 'https://www.twitch.tv/beldarkk' }
+    ],
+    'FT': [
+      { name: 'Mikeax2', url: 'https://www.twitch.tv/mikeax2' },
+      { name: 'nato', url: 'https://www.twitch.tv/natopotato262' },
+      { name: 'playb0x', url: 'https://www.twitch.tv/playb0x' }
+    ],
+    'HoE': [
+      { name: 'Katar', url: 'https://www.twitch.tv/karolk10' },
+      { name: 'gwej', url: 'https://www.twitch.tv/gwej' },
+      { name: 'cym3', url: 'https://www.twitch.tv/cymm3' }
+    ],
+    'Magic': [
+      { name: 'XRY', url: 'https://www.twitch.tv/xry_tv' },
+      { name: 'Splitsecond', url: 'https://www.twitch.tv/splitsecondta' },
+      { name: 'Howsya', url: 'https://www.twitch.tv/howsya' }
+    ],
+    'Tribal Therapy': [
+      { name: 'iinferno', url: 'https://www.twitch.tv/bschrift' },
+      { name: 'Blitz', url: 'https://www.twitch.tv/slohp0k3' },
+      { name: 'apc', url: 'https://www.twitch.tv/apcizzle' },
+      { name: 'Makasuro', url: 'https://www.twitch.tv/makasuro' }
+    ],
+    'UE': [
+      { name: 'PabloSexcrobar', url: 'https://www.twitch.tv/eltimablo' },
+      { name: 'RoamenCota', url: 'https://www.twitch.tv/roamencota' },
+      { name: 'Simmons', url: 'https://www.twitch.tv/simmons572' },
+      { name: 'Ghost_Loot', url: 'https://www.twitch.tv/ghost_loot' }
+    ]
+  };
+
   function getToken() {
     return localStorage.getItem(STORAGE_KEY);
   }
@@ -53,23 +120,50 @@
     }
   }
 
+  async function fetchLiveTeamStreams() {
+    const token = getToken();
+    if (!token) return [];
+    const logins = Object.values(TEAM_STREAMS).flat()
+      .map(s => {
+        const m = s.url.match(/twitch\.tv\/([^/?]+)/i);
+        return m ? m[1].toLowerCase() : null;
+      })
+      .filter(Boolean);
+    if (logins.length === 0) return [];
+    const query = logins.map(l => 'user_login=' + encodeURIComponent(l)).join('&');
+    try {
+      const res = await fetch('https://api.twitch.tv/helix/streams?' + query, {
+        headers: {
+          'Client-ID': CLIENT_ID,
+          'Authorization': 'Bearer ' + token
+        }
+      });
+      const json = await res.json();
+      return Array.isArray(json.data) ? json.data : [];
+    } catch (err) {
+      console.error('Failed to fetch team streams', err);
+      return [];
+    }
+  }
+
   function updateFollowedStreamsPanel() {
     const panel = document.getElementById('followed-streams-panel');
     if (!panel) return;
     panel.innerHTML = 'Loading...';
-    fetchFollowedStreams().then(streams => {
+    fetchLiveTeamStreams().then(streams => {
       if (!streams || streams.length === 0) {
-        panel.innerHTML = '<p class="text-sm">No followed streams live.</p>';
+        panel.innerHTML = '<p class="text-sm">No team streams live.</p>';
         return;
       }
       panel.innerHTML = '';
       streams.forEach(stream => {
-        const a = document.createElement('a');
-        a.href = `https://www.twitch.tv/${stream.user_login}`;
-        a.textContent = stream.user_name;
-        a.target = '_blank';
-        a.className = 'block hover:underline mb-2';
-        panel.appendChild(a);
+        const div = document.createElement('div');
+        div.className = 'live-box';
+        div.innerHTML = `
+          <span class="live-dot">\u25CF</span>
+          <a href="https://www.twitch.tv/${stream.user_login}" target="_blank" class="hover:underline">${stream.user_name}</a>
+        `;
+        panel.appendChild(div);
       });
     });
   }
@@ -149,6 +243,7 @@
     getToken,
     fetchUser,
     fetchFollowedStreams,
+    fetchLiveTeamStreams,
     updateFollowedStreamsPanel,
     initFollowedStreamsHover,
     updateNav,


### PR DESCRIPTION
## Summary
- style Scrim Watcher for an embedded chat panel
- embed a Twitch chat panel next to the match display
- populate channel list from selected team streams
- show a panel of live roster streams
- document that login is required for the followed streams panel
- fix team stream lookup to use the OAuth token

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688559194f1c832a9a021b4179a2d66c