### PR TITLE
Switch followed streams menu to click

### DIFF
--- a/FatboysofSummerDashBoard.html
+++ b/FatboysofSummerDashBoard.html
@@ -31,7 +31,7 @@
                 document.getElementById("nav-placeholder").innerHTML = html;
                 if (window.twitchOAuth) {
                     twitchOAuth.updateNav();
-                    twitchOAuth.initFollowedStreamsHover();
+                    twitchOAuth.initFollowedStreamsMenu();
                 }
             });
     </script>

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ The main navigation menu is stored in `nav.html`. Each page dynamically loads th
 Certain pages include a "Sign in with Twitch" button. Logging in stores your access token in `localStorage` so the site can personalize Twitch feeds. The login uses the [Twitch OAuth implicit flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#implicit-code-flow).
 When signed in, the main dashboard shows your Twitch username.
 
-In the navigation bar a **Followed Streams** button appears after you sign in with Twitch. Hovering over it slides in a panel listing any roster channels that are live on Twitch. Because the site queries the Twitch API using your token, being logged in is required for this list to populate.
-0
+In the navigation bar a **Followed Streams** button appears after you sign in with Twitch. Clicking the button toggles a side menu that lists any roster channels currently live. Clicking anywhere outside the menu closes it. Because the site queries the Twitch API using your token, being logged in is required for this list to populate.
 
 The teams dashboard also checks each roster's streamers against Twitch and highlights teams that are currently live.
 

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -38,10 +38,10 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById("nav-placeholder").innerHTML = html;
-        if (window.twitchOAuth) {
-          twitchOAuth.updateNav();
-          twitchOAuth.initFollowedStreamsHover();
-        }
+          if (window.twitchOAuth) {
+            twitchOAuth.updateNav();
+            twitchOAuth.initFollowedStreamsMenu();
+          }
       });
   </script>
   <div id="root"></div>

--- a/TribesRivalsTeamsDashboard.html
+++ b/TribesRivalsTeamsDashboard.html
@@ -69,7 +69,7 @@
                 document.getElementById("nav-placeholder").innerHTML = html;
                 if (window.twitchOAuth) {
                     twitchOAuth.updateNav();
-                    twitchOAuth.initFollowedStreamsHover();
+                    twitchOAuth.initFollowedStreamsMenu();
                 }
             });
     </script>

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -124,7 +124,7 @@
                 document.getElementById("nav-placeholder").innerHTML = html;
                 if (window.twitchOAuth) {
                     twitchOAuth.updateNav();
-                    twitchOAuth.initFollowedStreamsHover();
+                    twitchOAuth.initFollowedStreamsMenu();
                 }
             });
     </script>

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -301,10 +301,10 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById("nav-placeholder").innerHTML = html;
-        if (window.twitchOAuth) {
-          twitchOAuth.updateNav();
-          twitchOAuth.initFollowedStreamsHover();
-        }
+          if (window.twitchOAuth) {
+            twitchOAuth.updateNav();
+            twitchOAuth.initFollowedStreamsMenu();
+          }
       });
   </script>
   <div class="container">

--- a/nav.html
+++ b/nav.html
@@ -10,7 +10,7 @@
         <button id="twitch-login-btn" class="ml-4 bg-purple-600 text-white py-1 px-3 rounded hover:bg-purple-700"></button>
         <button id="followed-streams-toggle" class="ml-2 bg-gray-700 text-white py-1 px-3 rounded hover:bg-gray-800">Followed Streams</button>
         <span id="twitch-user" class="ml-2 text-purple-300" style="display:none;"></span>
-        <div id="followed-streams-panel" class="followed-streams-panel hidden absolute right-0 top-full bg-gray-800 text-white p-4 w-64 max-h-80 overflow-y-auto shadow-lg"></div>
+        <div id="followed-streams-panel" class="followed-streams-panel hidden fixed right-0 top-0 bottom-0 w-64 bg-gray-800 text-white p-4 overflow-y-auto shadow-lg"></div>
     </div>
 </nav>
 <style>

--- a/oauth.js
+++ b/oauth.js
@@ -169,18 +169,30 @@
     });
   }
 
-  function initFollowedStreamsHover() {
+  function initFollowedStreamsMenu() {
     const toggle = document.getElementById('followed-streams-toggle');
     const panel = document.getElementById('followed-streams-panel');
     if (!toggle || !panel) return;
 
-    const show = () => panel.classList.replace('hidden', 'visible');
-    const hide = () => panel.classList.replace('visible', 'hidden');
+    const togglePanel = (e) => {
+      e.stopPropagation();
+      if (panel.classList.contains('visible')) {
+        panel.classList.replace('visible', 'hidden');
+      } else {
+        panel.classList.replace('hidden', 'visible');
+      }
+    };
 
-    toggle.addEventListener('mouseenter', show);
-    toggle.addEventListener('mouseleave', hide);
-    panel.addEventListener('mouseenter', show);
-    panel.addEventListener('mouseleave', hide);
+    const handleClickOutside = (e) => {
+      if (!panel.contains(e.target) && !toggle.contains(e.target)) {
+        if (panel.classList.contains('visible')) {
+          panel.classList.replace('visible', 'hidden');
+        }
+      }
+    };
+
+    toggle.addEventListener('click', togglePanel);
+    document.addEventListener('click', handleClickOutside);
   }
 
   function loginWithTwitch() {
@@ -246,13 +258,13 @@
     fetchFollowedStreams,
     fetchLiveTeamStreams,
     updateFollowedStreamsPanel,
-    initFollowedStreamsHover,
+    initFollowedStreamsMenu,
     updateNav,
   };
 
 handleRedirect();
 document.addEventListener('DOMContentLoaded', () => {
   updateNav();
-  initFollowedStreamsHover();
+  initFollowedStreamsMenu();
 });
 })();


### PR DESCRIPTION
## Summary
- make the followed streams panel a fixed side menu
- toggle the menu with clicks instead of hover
- close the menu when clicking elsewhere
- update all pages and README for the new behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885a68e2ec8832ab1e3407c08c39a8e