### PR TITLE
Switch followed streams panel to left side

### DIFF
--- a/FatboysofSummerDashBoard.html
+++ b/FatboysofSummerDashBoard.html
@@ -31,7 +31,7 @@
                 document.getElementById("nav-placeholder").innerHTML = html;
                 if (window.twitchOAuth) {
                     twitchOAuth.updateNav();
-                    twitchOAuth.initFollowedStreamsHover();
+                    twitchOAuth.initLiveTeamsMenu();
                 }
             });
     </script>

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ The main navigation menu is stored in `nav.html`. Each page dynamically loads th
 Certain pages include a "Sign in with Twitch" button. Logging in stores your access token in `localStorage` so the site can personalize Twitch feeds. The login uses the [Twitch OAuth implicit flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#implicit-code-flow).
 When signed in, the main dashboard shows your Twitch username.
 
-In the navigation bar a **Followed Streams** button appears after you sign in with Twitch. Hovering over it slides in a panel listing any roster channels that are live on Twitch. Because the site queries the Twitch API using your token, being logged in is required for this list to populate.
-0
+In the navigation bar a **Live Teams** button appears after you sign in with Twitch. Clicking the button toggles a side menu that slides in from the left. On the teams dashboard the menu is positioned just below the "Tribes Rivals Dashboard" heading and above the "Select a Team" section. Clicking anywhere outside the menu closes it. Because the site queries the Twitch API using your token, being logged in is required for this list to populate.
 
 The teams dashboard also checks each roster's streamers against Twitch and highlights teams that are currently live.
 

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -38,10 +38,10 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById("nav-placeholder").innerHTML = html;
-        if (window.twitchOAuth) {
-          twitchOAuth.updateNav();
-          twitchOAuth.initFollowedStreamsHover();
-        }
+          if (window.twitchOAuth) {
+            twitchOAuth.updateNav();
+            twitchOAuth.initLiveTeamsMenu();
+          }
       });
   </script>
   <div id="root"></div>

--- a/TribesRivalsTeamsDashboard.html
+++ b/TribesRivalsTeamsDashboard.html
@@ -69,7 +69,9 @@
                 document.getElementById("nav-placeholder").innerHTML = html;
                 if (window.twitchOAuth) {
                     twitchOAuth.updateNav();
-                    twitchOAuth.initFollowedStreamsHover();
+                    twitchOAuth.initLiveTeamsMenu();
+                    const panel = document.getElementById('live-teams-panel');
+                    if (panel) panel.style.top = '9rem';
                 }
             });
     </script>
@@ -310,10 +312,10 @@
         </div>
     </section>
 
-    <!-- Followed Streams -->
-    <section id="followed-streams" class="container mx-auto px-4 py-12" style="display:none;">
-        <h2 class="text-3xl font-semibold text-center mb-8">Your Followed Streams</h2>
-        <div id="followedStreamsList" class="grid grid-cols-1 md:grid-cols-3 gap-6"></div>
+    <!-- Live Teams -->
+    <section id="live-teams" class="container mx-auto px-4 py-12" style="display:none;">
+        <h2 class="text-3xl font-semibold text-center mb-8">Live Teams</h2>
+        <div id="liveTeamsList" class="grid grid-cols-1 md:grid-cols-3 gap-6"></div>
     </section>
 
     <!-- Modal for Roster -->
@@ -503,8 +505,8 @@
             if (window.twitchOAuth && twitchOAuth.getToken()) {
                 twitchOAuth.fetchFollowedStreams().then(followed => {
                     if (!followed || followed.length === 0) return;
-                    const section = document.getElementById('followed-streams');
-                    const list = document.getElementById('followedStreamsList');
+                    const section = document.getElementById('live-teams');
+                    const list = document.getElementById('liveTeamsList');
                     followed.forEach(stream => {
                         const div = document.createElement('div');
                         div.className = 'bg-gray-800 p-6 rounded-lg shadow-lg text-center';

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -124,7 +124,7 @@
                 document.getElementById("nav-placeholder").innerHTML = html;
                 if (window.twitchOAuth) {
                     twitchOAuth.updateNav();
-                    twitchOAuth.initFollowedStreamsHover();
+                    twitchOAuth.initLiveTeamsMenu();
                 }
             });
     </script>

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -301,10 +301,10 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById("nav-placeholder").innerHTML = html;
-        if (window.twitchOAuth) {
-          twitchOAuth.updateNav();
-          twitchOAuth.initFollowedStreamsHover();
-        }
+          if (window.twitchOAuth) {
+            twitchOAuth.updateNav();
+            twitchOAuth.initLiveTeamsMenu();
+          }
       });
   </script>
   <div class="container">

--- a/nav.html
+++ b/nav.html
@@ -8,15 +8,15 @@
             <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
         </ul>
         <button id="twitch-login-btn" class="ml-4 bg-purple-600 text-white py-1 px-3 rounded hover:bg-purple-700"></button>
-        <button id="followed-streams-toggle" class="ml-2 bg-gray-700 text-white py-1 px-3 rounded hover:bg-gray-800">Followed Streams</button>
+        <button id="live-teams-toggle" class="ml-2 bg-gray-700 text-white py-1 px-3 rounded hover:bg-gray-800">Live Teams</button>
         <span id="twitch-user" class="ml-2 text-purple-300" style="display:none;"></span>
-        <div id="followed-streams-panel" class="followed-streams-panel hidden absolute right-0 top-full bg-gray-800 text-white p-4 w-64 max-h-80 overflow-y-auto shadow-lg"></div>
     </div>
 </nav>
+<div id="live-teams-panel" class="live-teams-panel hidden fixed left-0 top-36 bottom-0 w-64 bg-gray-800 text-white p-4 overflow-y-auto shadow-lg"></div>
 <style>
-  #followed-streams-panel { transition: transform 0.3s ease; }
-  #followed-streams-panel.hidden { transform: translateX(100%); }
-  #followed-streams-panel.visible { transform: translateX(0); }
+  #live-teams-panel { transition: transform 0.3s ease; }
+  #live-teams-panel.hidden { transform: translateX(-100%); }
+  #live-teams-panel.visible { transform: translateX(0); }
   .live-box {
     display: flex;
     align-items: center;

--- a/oauth.js
+++ b/oauth.js
@@ -147,8 +147,8 @@
     }
   }
 
-  function updateFollowedStreamsPanel() {
-    const panel = document.getElementById('followed-streams-panel');
+  function updateLiveTeamsPanel() {
+    const panel = document.getElementById('live-teams-panel');
     if (!panel) return;
     panel.innerHTML = 'Loading...';
     fetchLiveTeamStreams().then(streams => {
@@ -169,18 +169,30 @@
     });
   }
 
-  function initFollowedStreamsHover() {
-    const toggle = document.getElementById('followed-streams-toggle');
-    const panel = document.getElementById('followed-streams-panel');
+  function initLiveTeamsMenu() {
+    const toggle = document.getElementById('live-teams-toggle');
+    const panel = document.getElementById('live-teams-panel');
     if (!toggle || !panel) return;
 
-    const show = () => panel.classList.replace('hidden', 'visible');
-    const hide = () => panel.classList.replace('visible', 'hidden');
+    const togglePanel = (e) => {
+      e.stopPropagation();
+      if (panel.classList.contains('visible')) {
+        panel.classList.replace('visible', 'hidden');
+      } else {
+        panel.classList.replace('hidden', 'visible');
+      }
+    };
 
-    toggle.addEventListener('mouseenter', show);
-    toggle.addEventListener('mouseleave', hide);
-    panel.addEventListener('mouseenter', show);
-    panel.addEventListener('mouseleave', hide);
+    const handleClickOutside = (e) => {
+      if (!panel.contains(e.target) && !toggle.contains(e.target)) {
+        if (panel.classList.contains('visible')) {
+          panel.classList.replace('visible', 'hidden');
+        }
+      }
+    };
+
+    toggle.addEventListener('click', togglePanel);
+    document.addEventListener('click', handleClickOutside);
   }
 
   function loginWithTwitch() {
@@ -216,7 +228,7 @@
     const userSpan = document.getElementById('twitch-user');
 
     if (!btn) return;
-    const panel = document.getElementById('followed-streams-panel');
+    const panel = document.getElementById('live-teams-panel');
     if (getToken()) {
       btn.textContent = 'Sign out';
       btn.onclick = logoutTwitch;
@@ -228,7 +240,7 @@
           }
         });
       }
-      updateFollowedStreamsPanel();
+        updateLiveTeamsPanel();
     } else {
       btn.textContent = 'Sign in with Twitch';
       btn.onclick = loginWithTwitch;
@@ -245,14 +257,14 @@
     fetchUser,
     fetchFollowedStreams,
     fetchLiveTeamStreams,
-    updateFollowedStreamsPanel,
-    initFollowedStreamsHover,
+    updateLiveTeamsPanel,
+    initLiveTeamsMenu,
     updateNav,
   };
 
 handleRedirect();
 document.addEventListener('DOMContentLoaded', () => {
   updateNav();
-  initFollowedStreamsHover();
+  initLiveTeamsMenu();
 });
 })();


### PR DESCRIPTION
## Summary
- dock the followed streams panel on the left side of the screen
- slide the panel in from the left
- note left-side menu in the README
- move the panel below the "Tribes Rivals Dashboard" heading on the teams page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885a68e2ec8832ab1e3407c08c39a8e