### PR TITLE
Fix missing DPRK roster

### DIFF
--- a/TribesRivalsTeamsDashboard.html
+++ b/TribesRivalsTeamsDashboard.html
@@ -356,7 +356,7 @@
         const rosters = {
             'Avalanche': 'Captain: @Trinium Jones\nCore: BakaToma, Franchez, Dean, Ggglygy, Wriggles, Def_Monk\nAce: Proj',
             'ePidemic': 'Captain: @[ePi] Convik\nCore: Goshawk, Emma, Nanox, Blu, TartarosK\nBench: apo',
-            'DPRK': 'Roster information not available.',
+            'DPRK': 'Leader: Glem (MO)\nCo-Leader: CheezeCaeke (HOF)\nCaptain: ColonelFatso (Capper)\nCore: Nemesis (Capper), Rhino (LD), Halogen (LD), Panda (HO)',
             'Zen': 'Captain: @ℨ Gigz\nCore: Beamz, Hydroxide, Gnome, Slyce, Mikesters, Twin\nBench: Flocks\nNote: DM Cats/Glem to update the roster',
             'TXM': 'Captain: @OpCats (LO/LD)\nCore: Prizzo, Cryof, Amyou, Thatguy, Visis, Jive, Freefood, Howsya\nBench: Txredneck',
             'FPS': 'Captain: @S...\nCore: Brit, Icedwinds, Dugong, Beldark, Realhumanbeing, Simmons, Nightstar\nBench: Kilfaxi, Morokor',


### PR DESCRIPTION
## Summary
- add the DPRK player list on the teams dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68896520d120832a97e3b7d0fc58da13