### PR TITLE
Add Twins Tournament Data Center and events page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This repository contains a collection of static HTML pages for the community aro
 - **TribesScrimWatcher.html** – Utility for previewing scrimmage matchups and team rosters. Includes a chat box powered by Twitch embeds that appears alongside the match streams.
 - **TwitchFeedDisplays.html** – Layout for watching multiple Twitch streams at once.
 - **TwitchFeedMobile.html** – Mobile-friendly version of the Twitch feeds display.
-- **FatboysofSummerDashBoard.html** – Score-per-minute chart for a draft tournament.
+- **TwinsTournamentDataCenter.html** – Score-per-minute chart and documents for the tournament.
+- **UpcomingEvents.html** – Schedule of upcoming events with the Twins image.
 - **TeamBuilder.html** – Simple form for creating your own team with a logo and banner stored in your browser.
 - **MontageBay.html** – Submit montage video links and view them all in one place.
 - **Team*.html** – Individual team pages with logos, rosters, streams, and contact links. Teams include Avalanche, ePidemic, DPRK, Zen, TXM, Flag Pole Smokers, Flying Tractors, Hegemony of Euros, KTL, Magic, null, DeadStop, Toxic Aimers, and Unhandled Exception.
@@ -23,7 +24,8 @@ You can open these pages directly:
 - [Tournament Manager](TournamentManager.html)
 - [Twitch Feeds](TwitchFeedDisplays.html)
 - [Mobile Twitch Feeds](TwitchFeedMobile.html)
-- [Fatboys Dashboard](https://t24085.github.io/FatBoysofSummerDraft/dashboard)
+- [Twins Tournament Data Center](TwinsTournamentDataCenter.html)
+- [Upcoming Events](UpcomingEvents.html)
 
 
 ## Usage

--- a/TwinsTournamentDataCenter.html
+++ b/TwinsTournamentDataCenter.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Score / Minute Chart</title>
+    <title>Twins Tournament Data Center</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="oauth.js"></script>
@@ -36,7 +36,13 @@
             });
     </script>
 
-    <canvas id="scoreChart"></canvas>
+    <h1 class="text-3xl font-bold text-center mt-4">Twins Tournament Data Center</h1>
+    <canvas id="scoreChart" class="mt-4"></canvas>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4">
+        <iframe class="w-full h-96 bg-white" src="https://docs.google.com/spreadsheets/d/1M5dJfcEiItfreB-Ohi5TjncRmc-JFBPbetRbRT1ixZs/preview"></iframe>
+        <iframe class="w-full h-96 bg-white" src="https://docs.google.com/spreadsheets/d/18czntt-rJvPamT0tnEYJVSgn7O-HJn_kfai9OTEOZ44/preview"></iframe>
+        <iframe class="w-full h-96 bg-white" src="https://docs.google.com/spreadsheets/d/19lOvDGNiaUJ7wkBwgROez_UXkjhrJQe21i07lPrhab8/preview"></iframe>
+    </div>
 
     <script>
         const players = ["PR0J", "DareDevilMoon", "Dugong", "Nemesis", "nomlfir", "kwago", "Annihilation", "DeadManWalking", "Barracuda",

--- a/TwitchFeedMobile.html
+++ b/TwitchFeedMobile.html
@@ -299,7 +299,8 @@
         <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
         <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
         <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-        <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
+        <li><a href="TwinsTournamentDataCenter.html" class="hover:text-blue-400 transition">Twins Tournament Data Center</a></li>
+        <li><a href="UpcomingEvents.html" class="hover:text-blue-400 transition">Upcoming Events</a></li>
       </ul>
     </div>
   </nav>

--- a/UpcomingEvents.html
+++ b/UpcomingEvents.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Upcoming Events</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white">
+    <div id="nav-placeholder"></div>
+    <script>
+        fetch('nav.html').then(r => r.text()).then(html => {
+            document.getElementById('nav-placeholder').innerHTML = html;
+            if (window.twitchOAuth) {
+                twitchOAuth.updateNav();
+                twitchOAuth.initLiveTeamsMenu();
+            }
+        });
+    </script>
+    <main class="container mx-auto p-4">
+        <h1 class="text-3xl font-bold mb-4 text-center">Upcoming Events</h1>
+        <img src="Twin.jpg" alt="Twins" class="mx-auto mb-4 max-w-xs">
+        <iframe class="w-full h-[75vh] bg-white" src="https://docs.google.com/document/d/1wkWiFoTMbQoMkguv-cMBVqpg3hZzY0RJrZ9egVOWoNo/preview"></iframe>
+    </main>
+</body>
+</html>

--- a/nav.html
+++ b/nav.html
@@ -5,7 +5,8 @@
             <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
             <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
             <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
-            <li><a href="https://t24085.github.io/FatBoysofSummerDraft/dashboard" class="hover:text-blue-400 transition">Fatboys Dashboard</a></li>
+            <li><a href="TwinsTournamentDataCenter.html" class="hover:text-blue-400 transition">Twins Tournament Data Center</a></li>
+            <li><a href="UpcomingEvents.html" class="hover:text-blue-400 transition">Upcoming Events</a></li>
             <!-- <li><a href="TeamBuilder.html" class="hover:text-blue-400 transition">Create Team</a></li> -->
             <!-- <li><a href="MontageBay.html" class="hover:text-blue-400 transition">Montage Bay</a></li> -->
         </ul>


### PR DESCRIPTION
## Summary
- rename FatboysofSummerDashBoard.html to TwinsTournamentDataCenter.html
- embed tourney spreadsheets in the new data center
- update nav and TwitchFeedMobile links
- document new pages in README
- add UpcomingEvents.html with Twin.jpg and schedule

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688bec36b878832ab43e58c524c7a7e0