### PR TITLE
Update Data Center with new sheet links

### DIFF
--- a/TwinsTournamentDataCenter.html
+++ b/TwinsTournamentDataCenter.html
@@ -6,6 +6,7 @@
     <title>Fat Boys of Summer Draft Dashboard</title>
     <!-- Tailwind CSS CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="oauth.js"></script>
     <!-- React and Dependencies -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.8.1/prop-types.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"></script>
@@ -85,6 +86,16 @@
     </style>
 </head>
 <body class="text-white min-h-screen">
+    <div id="nav-placeholder"></div>
+    <script>
+        fetch("nav.html").then(r => r.text()).then(html => {
+            document.getElementById("nav-placeholder").innerHTML = html;
+            if (window.twitchOAuth) {
+                twitchOAuth.updateNav();
+                twitchOAuth.initLiveTeamsMenu();
+            }
+        });
+    </script>
     <div id="root"></div>
 
     <script type="text/babel">
@@ -136,6 +147,14 @@
                     { name: "Returns (Raw)", url: "https://t24085.github.io/FatBoysofSummerDraft/returnsraw" },
                     { name: "Returns per Minute", url: "https://t24085.github.io/FatBoysofSummerDraft/returnsminute" },
                     { name: "Returns (Team Data)", url: "https://t24085.github.io/FatBoysofSummerDraft/returnsteamdata" }
+                ]
+            },
+            {
+                category: "Additional Sheets",
+                items: [
+                    { name: "Draft #7 (9v9) June 21st 2025 (Public)", url: "https://docs.google.com/spreadsheets/d/1M5dJfcEiItfreB-Ohi5TjncRmc-JFBPbetRbRT1ixZs/edit?gid=589907287#gid=589907287" },
+                    { name: "Additional Stats Document", url: "https://docs.google.com/spreadsheets/d/18czntt-rJvPamT0tnEYJVSgn7O-HJn_kfai9OTEOZ44/" },
+                    { name: "Draft #5 Statistics (cooked)", url: "https://docs.google.com/spreadsheets/d/19lOvDGNiaUJ7wkBwgROez_UXkjhrJQe21i07lPrhab8" }
                 ]
             }
         ];


### PR DESCRIPTION
## Summary
- add Twitch authentication script to `TwinsTournamentDataCenter.html`
- load common navigation bar on the page
- include additional Google Sheets links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bf7e0864c832a90f3b1bf0aed9b2b