### PR TITLE
Update Data Center with embedded sheets

### DIFF
--- a/TwinsTournamentDataCenter.html
+++ b/TwinsTournamentDataCenter.html
@@ -6,6 +6,7 @@
     <title>Fat Boys of Summer Draft Dashboard</title>
     <!-- Tailwind CSS CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="oauth.js"></script>
     <!-- React and Dependencies -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.8.1/prop-types.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"></script>
@@ -85,6 +86,16 @@
     </style>
 </head>
 <body class="text-white min-h-screen">
+    <div id="nav-placeholder"></div>
+    <script>
+        fetch("nav.html").then(r => r.text()).then(html => {
+            document.getElementById("nav-placeholder").innerHTML = html;
+            if (window.twitchOAuth) {
+                twitchOAuth.updateNav();
+                twitchOAuth.initLiveTeamsMenu();
+            }
+        });
+    </script>
     <div id="root"></div>
 
     <script type="text/babel">
@@ -137,6 +148,14 @@
                     { name: "Returns per Minute", url: "https://t24085.github.io/FatBoysofSummerDraft/returnsminute" },
                     { name: "Returns (Team Data)", url: "https://t24085.github.io/FatBoysofSummerDraft/returnsteamdata" }
                 ]
+            },
+            {
+                category: "Additional Sheets",
+                items: [
+                    { name: "Draft #7 (9v9) June 21st 2025 (Public)", url: "https://docs.google.com/spreadsheets/d/1M5dJfcEiItfreB-Ohi5TjncRmc-JFBPbetRbRT1ixZs/edit?gid=589907287#gid=589907287", embed: true },
+                    { name: "Additional Stats Document", url: "https://docs.google.com/spreadsheets/d/18czntt-rJvPamT0tnEYJVSgn7O-HJn_kfai9OTEOZ44/", embed: true },
+                    { name: "Draft #5 Statistics (cooked)", url: "https://docs.google.com/spreadsheets/d/19lOvDGNiaUJ7wkBwgROez_UXkjhrJQe21i07lPrhab8", embed: true }
+                ]
             }
         ];
 
@@ -154,6 +173,29 @@
             );
         };
 
+        // EmbedSheetCard component for displaying Google Sheets
+        const EmbedSheetCard = ({ name, url }) => {
+            const [show, setShow] = React.useState(false);
+            const embedUrl = url.split('/edit')[0].replace(/\/$/, '') + '/preview';
+            return (
+                <div className="link-card p-6 rounded-lg neon-glow transition duration-300 transform">
+                    <button
+                        onClick={() => setShow(!show)}
+                        className="text-lg font-semibold text-orange-200 w-full text-left"
+                    >
+                        {name}
+                    </button>
+                    {show && (
+                        <iframe
+                            src={embedUrl}
+                            className="w-full h-96 mt-4 bg-white rounded"
+                            loading="lazy"
+                        ></iframe>
+                    )}
+                </div>
+            );
+        };
+
         // CategorySection component
         const CategorySection = ({ category, items }) => {
             return (
@@ -161,7 +203,11 @@
                     <h2 className="text-3xl font-bold mb-6 text-pink-300 category-title">{category}</h2>
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
                         {items.map((item, index) => (
-                            <LinkCard key={index} name={item.name} url={item.url} />
+                            item.embed ? (
+                                <EmbedSheetCard key={index} name={item.name} url={item.url} />
+                            ) : (
+                                <LinkCard key={index} name={item.name} url={item.url} />
+                            )
                         ))}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- embed Google Sheets in `TwinsTournamentDataCenter.html`
- add collapsible embed component and toggle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bf7e0864c832a90f3b1bf0aed9b2b