### PR TITLE
Add Firebase team signup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a collection of static HTML pages for the community aro
 - **TwitchFeedMobile.html** – Mobile-friendly version of the Twitch feeds display.
 - **TwinsTournamentDataCenter.html** – Score-per-minute chart and documents for the tournament.
 - **UpcomingEvents.html** – Schedule of upcoming events with the Twins image.
+- **TeamSignUp.html** – Register new teams and edit their rosters using Firebase.
 - **TeamBuilder.html** – Simple form for creating your own team with a logo and banner stored in your browser.
 - **MontageBay.html** – Submit montage video links and view them all in one place.
 - **Team*.html** – Individual team pages with logos, rosters, streams, and contact links. Teams include Avalanche, ePidemic, DPRK, Zen, TXM, Flag Pole Smokers, Flying Tractors, Hegemony of Euros, KTL, Magic, null, DeadStop, Toxic Aimers, and Unhandled Exception.
@@ -26,6 +27,7 @@ You can open these pages directly:
 - [Mobile Twitch Feeds](TwitchFeedMobile.html)
 - [Twins Tournament Data Center](TwinsTournamentDataCenter.html)
 - [Upcoming Events](UpcomingEvents.html)
+- [Team Sign-Up](TeamSignUp.html)
 
 
 ## Usage
@@ -45,6 +47,17 @@ When signed in, the main dashboard shows your Twitch username.
 In the navigation bar a **Live Teams** button appears after you sign in with Twitch. Clicking the button toggles a side menu that slides in from the left. On the teams dashboard the menu is positioned just below the "Tribes Rivals Dashboard" heading and above the "Select a Team" section. Clicking anywhere outside the menu closes it. Because the site queries the Twitch API using your token, being logged in is required for this list to populate.
 
 The teams dashboard also checks each roster's streamers against Twitch and highlights teams that are currently live.
+
+## Firebase Setup for Team Sign-Up
+
+The `TeamSignUp.html` page uses [Firebase Firestore](https://firebase.google.com/docs/firestore) to store team data. To use it:
+
+1. Create a project at <https://console.firebase.google.com> and add a **Web App**. Copy the configuration snippet it provides.
+2. Enable **Cloud Firestore** in your Firebase project. Start in test mode unless you have security rules prepared.
+3. Replace the placeholder values in `TeamSignUp.html` under `firebaseConfig` with your project credentials. All keys, including `apiKey`, `authDomain`, `projectId`, `storageBucket`, `messagingSenderId`, and `appId`, must match the values from Firebase.
+   The `storageBucket` entry should end with `.appspot.com` (for example `your-project.appspot.com`).
+4. Deploy the site or run a local server (e.g. `python3 -m http.server`) before opening the page. Submitting the form stores teams under a `teams` collection in Firestore.
+5. Returning to the page will list existing teams and let you edit or delete them.
 
 ## Credits
 

--- a/TeamSignUp.html
+++ b/TeamSignUp.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Team Sign-Up</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+      }
+    });
+  </script>
+  <main class="container mx-auto p-4">
+    <h1 class="text-3xl font-bold text-center mb-4">New Team Sign-Up</h1>
+    <form id="team-form" class="space-y-4 max-w-2xl mx-auto">
+      <input id="team-name" type="text" placeholder="Team Name" class="w-full p-2 rounded bg-gray-800" required>
+      <input id="team-tag" type="text" placeholder="Team Tag" class="w-full p-2 rounded bg-gray-800" required>
+      <div id="players-section" class="space-y-2"></div>
+      <button type="button" id="add-bench" class="bg-gray-700 hover:bg-gray-800 px-3 py-1 rounded">Add Bench Player</button>
+      <button type="submit" class="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded">Save Team</button>
+    </form>
+    <section id="team-list" class="mt-8 space-y-4 max-w-2xl mx-auto"></section>
+  </main>
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-app.js';
+    import {
+      getFirestore,
+      collection,
+      getDocs,
+      addDoc,
+      doc,
+      setDoc,
+      deleteDoc
+    } from 'https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js';
+
+    const firebaseConfig = {
+      apiKey: "YOUR_API_KEY",
+      authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+      projectId: "YOUR_PROJECT_ID",
+      storageBucket: "YOUR_PROJECT_ID.appspot.com",
+      messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+      appId: "YOUR_APP_ID"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getFirestore(app);
+
+    function playerRow(name = '', twitch = '', isBench = false) {
+      const div = document.createElement('div');
+      div.className = 'grid grid-cols-2 gap-2';
+      div.innerHTML = `
+        <input type="text" placeholder="Player Name" value="${name}" class="p-2 rounded bg-gray-800 player-name">
+        <input type="text" placeholder="Twitch Channel" value="${twitch}" class="p-2 rounded bg-gray-800 player-twitch">
+      `;
+      div.dataset.bench = isBench;
+      return div;
+    }
+
+    function loadInitialPlayers() {
+      const section = document.getElementById('players-section');
+      section.innerHTML = '';
+      for (let i = 0; i < 7; i++) {
+        section.appendChild(playerRow());
+      }
+    }
+
+    document.getElementById('add-bench').addEventListener('click', () => {
+      document.getElementById('players-section').appendChild(playerRow('', '', true));
+    });
+
+    loadInitialPlayers();
+
+    async function loadTeams() {
+      const list = document.getElementById('team-list');
+      list.innerHTML = '';
+      const snapshot = await getDocs(collection(db, 'teams'));
+      snapshot.forEach(docSnap => {
+        const team = docSnap.data();
+        const div = document.createElement('div');
+        div.className = 'bg-gray-800 p-4 rounded';
+        div.innerHTML = `<h2 class="text-xl font-semibold mb-2">${team.name} (${team.tag})</h2>`;
+
+        const ul = document.createElement('ul');
+        team.players.forEach(p => {
+          const li = document.createElement('li');
+          const twitchLink = p.twitch ? `<a href="https://twitch.tv/${p.twitch}" class="text-purple-400" target="_blank">@${p.twitch}</a>` : '';
+          li.innerHTML = `${p.name} ${twitchLink} ${p.isBench ? '(Bench)' : ''}`;
+          ul.appendChild(li);
+        });
+        div.appendChild(ul);
+
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.className = 'bg-green-600 hover:bg-green-700 px-2 py-1 rounded mr-2';
+        editBtn.onclick = () => editTeam(docSnap.id, team);
+        div.appendChild(editBtn);
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Delete';
+        delBtn.className = 'bg-red-600 hover:bg-red-700 px-2 py-1 rounded';
+        delBtn.onclick = () => deleteTeam(docSnap.id);
+        div.appendChild(delBtn);
+
+        list.appendChild(div);
+      });
+    }
+
+    async function deleteTeam(id) {
+      if (confirm('Delete this team?')) {
+        await deleteDoc(doc(db, 'teams', id));
+        loadTeams();
+      }
+    }
+
+    let editingId = null;
+    function editTeam(id, team) {
+      editingId = id;
+      document.getElementById('team-name').value = team.name;
+      document.getElementById('team-tag').value = team.tag;
+      const section = document.getElementById('players-section');
+      section.innerHTML = '';
+      team.players.forEach(p => section.appendChild(playerRow(p.name, p.twitch, p.isBench)));
+    }
+
+    document.getElementById('team-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      try {
+        const name = document.getElementById('team-name').value.trim();
+        const tag = document.getElementById('team-tag').value.trim();
+        const players = Array.from(document.querySelectorAll('#players-section > div')).map(div => ({
+          name: div.querySelector('.player-name').value.trim(),
+          twitch: div.querySelector('.player-twitch').value.trim(),
+          isBench: div.dataset.bench === 'true'
+        })).filter(p => p.name);
+        const data = { name, tag, players };
+        if (editingId) {
+          await setDoc(doc(db, 'teams', editingId), data);
+          editingId = null;
+        } else {
+          await addDoc(collection(db, 'teams'), data);
+        }
+        e.target.reset();
+        loadInitialPlayers();
+        loadTeams();
+      } catch (err) {
+        console.error('Failed to save team:', err);
+        alert('Error saving team. Check the console for details.');
+      }
+    });
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', loadTeams);
+    } else {
+      loadTeams();
+    }
+  </script>
+</body>
+</html>

--- a/nav.html
+++ b/nav.html
@@ -7,6 +7,7 @@
             <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
             <li><a href="TwinsTournamentDataCenter.html" class="hover:text-blue-400 transition">Twins Tournament Data Center</a></li>
             <li><a href="UpcomingEvents.html" class="hover:text-blue-400 transition">Upcoming Events</a></li>
+            <li><a href="TeamSignUp.html" class="hover:text-blue-400 transition">Team Sign-Up</a></li>
             <!-- <li><a href="TeamBuilder.html" class="hover:text-blue-400 transition">Create Team</a></li> -->
             <!-- <li><a href="MontageBay.html" class="hover:text-blue-400 transition">Montage Bay</a></li> -->
         </ul>


### PR DESCRIPTION
## Summary
- add a Team Sign-Up page backed by Firebase Firestore
- switch to Firebase module imports and show rosters in the team list
- document the required Firebase config values in README
- clarify bucket domain and local hosting instructions
- handle errors when saving a team and ensure teams load on page open

## Testing
- `echo "no tests"`


------
https://chatgpt.com/codex/tasks/task_e_688cdebc7fac832ab72dae3cc47792db