### PR TITLE
Add navigation bar to draft signup and bracket pages

### DIFF
--- a/DraftSignUp.html
+++ b/DraftSignUp.html
@@ -48,6 +48,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="oauth.js"></script>
   <!-- Firebase SDK -->
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
@@ -72,6 +73,18 @@
   </style>
 </head>
 <body class="text-white">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+        const panel = document.getElementById('live-teams-panel');
+        if (panel) panel.style.top = '9rem';
+      }
+    });
+  </script>
   <div id="root"></div>
   <script type="text/babel">
     const POSITIONS = ['HoF', 'LD', 'MD', 'MO', 'HO', 'LO', 'Capper'];

--- a/TournamentBrackets.html
+++ b/TournamentBrackets.html
@@ -9,6 +9,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="oauth.js"></script>
   <style>
     body {
       background-image: url('https://github.com/T24085/images/blob/main/ss_fe25c58da0c50913fac070eea8150ee2e3cb178d.1920x1080.jpg?raw=true');
@@ -81,6 +82,18 @@
   </style>
 </head>
 <body class="text-white">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+        const panel = document.getElementById('live-teams-panel');
+        if (panel) panel.style.top = '9rem';
+      }
+    });
+  </script>
   <div id="root"></div>
   <script type="text/babel">
     const Match = ({ match, roundIndex, matchIndex, onSubmitScores, tournamentStyle, matchHeight, positionTop, nextMatchPosition, prevMatchPositions }) => {

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -309,7 +309,7 @@
             <h2 className="text-2xl font-bold mb-4">Related Pages</h2>
             <div className="flex gap-4">
               <a
-                href="https://t24085.github.io/DraftSignUp/"
+                href="DraftSignUp.html"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
@@ -317,7 +317,7 @@
                 Draft Sign-Up Sheet
               </a>
               <a
-                href="https://t24085.github.io/Tournament-Bracket/"
+                href="TournamentBrackets.html"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/nav.html
+++ b/nav.html
@@ -3,11 +3,11 @@
         <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
             <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
             <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
-            <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
+            <li><a href="TournamentBrackets.html" class="hover:text-blue-400 transition">Tournament Brackets</a></li>
             <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
             <li><a href="TwinsTournamentDataCenter.html" class="hover:text-blue-400 transition">Twins Tournament Data Center</a></li>
             <li><a href="UpcomingEvents.html" class="hover:text-blue-400 transition">Upcoming Events</a></li>
-            <li><a href="TeamSignUp.html" class="hover:text-blue-400 transition">Team Sign-Up</a></li>
+            <li><a href="DraftSignUp.html" class="hover:text-blue-400 transition">Draft Sign-Up</a></li>
             <!-- <li><a href="TeamBuilder.html" class="hover:text-blue-400 transition">Create Team</a></li> -->
             <!-- <li><a href="MontageBay.html" class="hover:text-blue-400 transition">Montage Bay</a></li> -->
         </ul>


### PR DESCRIPTION
## Summary
- integrate shared nav bar and Twitch auth on Draft Sign-Up and Tournament Brackets pages
- load nav.html dynamically and initialize live teams panel
- update nav links to point to new Draft Sign-Up and Tournament Brackets pages
- link Tournament Manager to the local Draft Sign-Up and Tournament Brackets pages so the nav bar loads correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f8fb60330832abb6f8ce2301eb2ed