### PR TITLE
Add navigation bar to draft signup and bracket pages

### DIFF
--- a/DraftSignUp.html
+++ b/DraftSignUp.html
@@ -48,6 +48,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="oauth.js"></script>
   <!-- Firebase SDK -->
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
@@ -72,6 +73,18 @@
   </style>
 </head>
 <body class="text-white">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+        const panel = document.getElementById('live-teams-panel');
+        if (panel) panel.style.top = '9rem';
+      }
+    });
+  </script>
   <div id="root"></div>
   <script type="text/babel">
     const POSITIONS = ['HoF', 'LD', 'MD', 'MO', 'HO', 'LO', 'Capper'];

--- a/LiveAnnouncementBanner.jsx
+++ b/LiveAnnouncementBanner.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+
+export default function LiveAnnouncementBanner() {
+  const [activeAnnouncements, setActiveAnnouncements] = useState([]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadAnnouncements = async () => {
+      try {
+        const res = await fetch('/announcements.json');
+        const data = await res.json();
+        const now = new Date();
+        const active = data.filter(({ startTime, endTime }) => {
+          const start = new Date(startTime);
+          const end = new Date(endTime);
+          return now >= start && now <= end;
+        });
+        if (isMounted) {
+          setActiveAnnouncements(active);
+        }
+      } catch (err) {
+        console.error('Unable to load announcements', err);
+      }
+    };
+
+    loadAnnouncements();
+    const intervalId = setInterval(loadAnnouncements, 60 * 1000);
+    return () => {
+      isMounted = false;
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  if (!activeAnnouncements.length) {
+    return null;
+  }
+
+  return (
+    <div style={{ position: 'fixed', top: 0, left: 0, width: '100%', zIndex: 1000 }}>
+      {activeAnnouncements.map((announcement, index) => (
+        <div key={index} className="lab-banner">
+          {announcement.message}
+        </div>
+      ))}
+      <style>{`
+        .lab-banner {
+          background: #111;
+          color: #fff;
+          padding: 10px;
+          text-align: center;
+          font-size: 1rem;
+          animation: lab-glow 2s ease-in-out infinite alternate;
+        }
+
+        @keyframes lab-glow {
+          from {
+            text-shadow: 0 0 5px #fff, 0 0 10px #fff;
+          }
+          to {
+            text-shadow: 0 0 20px #fff, 0 0 30px #fff;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/TournamentBrackets.html
+++ b/TournamentBrackets.html
@@ -9,6 +9,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="oauth.js"></script>
   <style>
     body {
       background-image: url('https://github.com/T24085/images/blob/main/ss_fe25c58da0c50913fac070eea8150ee2e3cb178d.1920x1080.jpg?raw=true');
@@ -81,6 +82,18 @@
   </style>
 </head>
 <body class="text-white">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+        const panel = document.getElementById('live-teams-panel');
+        if (panel) panel.style.top = '9rem';
+      }
+    });
+  </script>
   <div id="root"></div>
   <script type="text/babel">
     const Match = ({ match, roundIndex, matchIndex, onSubmitScores, tournamentStyle, matchHeight, positionTop, nextMatchPosition, prevMatchPositions }) => {
@@ -1498,7 +1511,7 @@
             <h2 className="text-2xl font-bold mb-4">Related Pages</h2>
             <div className="flex gap-4">
               <a
-                href="https://t24085.github.io/DraftSignUp/"
+                href="https://t24085.github.io/ProjectTribes/DraftSignUp.html"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
@@ -1506,7 +1519,7 @@
                 Draft Sign-Up Sheet
               </a>
               <a
-                href="https://t24085.github.io/Tournament-Manager/"
+                href="https://t24085.github.io/ProjectTribes/TournamentManager.html"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -309,7 +309,7 @@
             <h2 className="text-2xl font-bold mb-4">Related Pages</h2>
             <div className="flex gap-4">
               <a
-                href="https://t24085.github.io/DraftSignUp/"
+                href="DraftSignUp.html"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
@@ -317,7 +317,7 @@
                 Draft Sign-Up Sheet
               </a>
               <a
-                href="https://t24085.github.io/Tournament-Bracket/"
+                href="TournamentBrackets.html"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/announcements.json
+++ b/announcements.json
@@ -1,0 +1,7 @@
+[
+  {
+    "message": "Welcome to Project Tribes!",
+    "startTime": "2020-01-01T00:00:00Z",
+    "endTime": "2030-01-01T00:00:00Z"
+  }
+]

--- a/nav.html
+++ b/nav.html
@@ -3,7 +3,7 @@
         <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
             <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
             <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
-            <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
+            <li><a href="TournamentBrackets.html" class="hover:text-blue-400 transition">Tournament Brackets</a></li>
             <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
             <li><a href="TwinsTournamentDataCenter.html" class="hover:text-blue-400 transition">Twins Tournament Data Center</a></li>
             <li><a href="UpcomingEvents.html" class="hover:text-blue-400 transition">Upcoming Events</a></li>


### PR DESCRIPTION
## Summary
- integrate shared nav bar and Twitch auth on Draft Sign-Up and Tournament Brackets pages
- load nav.html dynamically and initialize live teams panel
- update nav links to point to new Draft Sign-Up and Tournament Brackets pages
- link Tournament Manager to the local Draft Sign-Up and Tournament Brackets pages so the nav bar loads correctly
- point bracket page buttons to hosted Draft Sign-Up and Tournament Manager URLs
- add LiveAnnouncementBanner React component that shows time-bound announcements from a local JSON file
- restore Team Sign-Up link in navigation bar instead of draft sign-up

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f8fb60330832abb6f8ce2301eb2ed