### PR TITLE
Add Firestore-backed streamer pages with admin management and public submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ This repository contains a collection of static HTML pages for the community aro
 - **TwinsTournamentDataCenter.html** – Score-per-minute chart and documents for the tournament.
 - **UpcomingEvents.html** – Schedule of upcoming events with the Twins image.
 - **TeamSignUp.html** – Register new teams and edit their rosters using Firebase.
+- **Streamers.html** – Public directory of approved streamers loaded from Firestore.
+- **StreamersSubmit.html** – Form for anyone to submit a streamer for admin approval.
+- **StreamersAdmin.html** – Protected panel for approving or removing streamer entries.
 - **TeamBuilder.html** – Simple form for creating your own team with a logo and banner stored in your browser.
 - **MontageBay.html** – Submit montage video links and view them all in one place.
 - **Team*.html** – Individual team pages with logos, rosters, streams, and contact links. Teams include Avalanche, ePidemic, DPRK, Zen, TXM, Flag Pole Smokers, Flying Tractors, Hegemony of Euros, KTL, Magic, null, DeadStop, Toxic Aimers, and Unhandled Exception.
@@ -28,6 +31,9 @@ You can open these pages directly:
 - [Twins Tournament Data Center](TwinsTournamentDataCenter.html)
 - [Upcoming Events](UpcomingEvents.html)
 - [Team Sign-Up](TeamSignUp.html)
+- [Streamers](Streamers.html)
+- [Submit a Streamer](StreamersSubmit.html)
+- [Streamers Admin](StreamersAdmin.html)
 
 
 ## Usage
@@ -56,7 +62,7 @@ The `TeamSignUp.html` page uses [Firebase Firestore](https://firebase.google.com
 2. Enable **Cloud Firestore** in your Firebase project. Start in test mode unless you have security rules prepared.
 
 3. Replace the placeholder values in `TeamSignUp.html` under `firebaseConfig` with your project credentials. All keys, including `apiKey`, `authDomain`, `projectId`, `storageBucket`, `messagingSenderId`, and `appId`, must match the values from Firebase.
-   The `storageBucket` entry should end with `.appspot.com` (for example `your-project.appspot.com`).
+   The `storageBucket` entry should match the domain provided by Firebase (typically ending in `.appspot.com` or `.firebasestorage.app`).
 4. Deploy the site or run a local server (e.g. `python3 -m http.server`) before opening the page. Submitting the form stores teams under a `teams` collection in Firestore.
 
 5. Returning to the page will list existing teams and let you edit or delete them.

--- a/Streamers.html
+++ b/Streamers.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Streamers</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+        const panel = document.getElementById('live-teams-panel');
+        if (panel) panel.style.top = '9rem';
+      }
+    });
+  </script>
+
+  <div class="container mx-auto px-4 mt-8">
+    <h1 class="text-3xl font-bold text-center mb-6">Tribes Streamers</h1>
+    <div class="text-right mb-4">
+      <a href="StreamersSubmit.html" class="text-green-400 hover:underline">Submit a streamer</a>
+    </div>
+    <p id="noStreamers" class="hidden text-center text-gray-400">No approved streamers yet. <a href="StreamersSubmit.html" class="underline">Submit one?</a></p>
+    <div id="streamersGrid" class="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div>
+  </div>
+
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+    import { getFirestore, collection, getDocs, query, where } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
+      authDomain: "team-sign-up-b5646.firebaseapp.com",
+      projectId: "team-sign-up-b5646",
+      storageBucket: "team-sign-up-b5646.firebasestorage.app",
+      messagingSenderId: "951471144681",
+      appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getFirestore(app);
+
+    const grid = document.getElementById('streamersGrid');
+
+    async function loadStreamers() {
+      grid.innerHTML = '';
+      document.getElementById('noStreamers').classList.add('hidden');
+      const q = query(collection(db, 'streamers'), where('approved', '==', true));
+      const snap = await getDocs(q);
+      if (snap.empty) {
+        document.getElementById('noStreamers').classList.remove('hidden');
+        return;
+      }
+      snap.forEach(doc => {
+        const data = doc.data();
+        const card = document.createElement('div');
+        card.className = 'bg-gray-800 rounded-lg overflow-hidden shadow-lg';
+        card.innerHTML = `
+          <img src="${data.avatarUrl || 'https://placehold.co/300x200'}" alt="${data.displayName}" class="w-full h-48 object-cover">
+          <div class="p-4">
+            <h2 class="text-xl font-semibold mb-2">${data.displayName}</h2>
+            ${data.team ? `<p class=\"text-sm mb-2\">Team: ${data.team}</p>` : ''}
+            <a href="https://twitch.tv/${data.twitchHandle}" target="_blank" class="text-purple-400 hover:underline">twitch.tv/${data.twitchHandle}</a>
+          </div>
+        `;
+        grid.appendChild(card);
+      });
+    }
+
+    loadStreamers().catch(() => document.getElementById('noStreamers').classList.remove('hidden'));
+  </script>
+</body>
+</html>

--- a/StreamersAdmin.html
+++ b/StreamersAdmin.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Streamer Admin</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+        const panel = document.getElementById('live-teams-panel');
+        if (panel) panel.style.top = '9rem';
+      }
+    });
+  </script>
+
+  <div id="loginDiv" class="max-w-sm mx-auto mt-10 space-y-4">
+    <h1 class="text-2xl font-bold text-center">Admin Login</h1>
+    <input id="email" type="email" placeholder="Email" class="w-full px-3 py-2 rounded bg-gray-800 border border-gray-700" />
+    <input id="password" type="password" placeholder="Password" class="w-full px-3 py-2 rounded bg-gray-800 border border-gray-700" />
+    <button id="loginBtn" class="w-full py-2 bg-blue-600 hover:bg-blue-700 rounded">Login</button>
+  </div>
+
+  <div id="adminPanel" class="hidden container mx-auto px-4 mt-8">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-3xl font-bold">Manage Streamers</h1>
+      <button id="logoutBtn" class="py-2 px-4 bg-red-600 hover:bg-red-700 rounded">Logout</button>
+    </div>
+
+    <form id="addStreamerForm" class="space-y-4 mb-8">
+      <div>
+        <label class="block text-sm mb-1">Display Name</label>
+        <input id="displayName" type="text" required class="w-full px-3 py-2 rounded bg-gray-800 border border-gray-700" />
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Twitch Handle</label>
+        <input id="twitchHandle" type="text" required class="w-full px-3 py-2 rounded bg-gray-800 border border-gray-700" />
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Team (optional)</label>
+        <input id="team" type="text" class="w-full px-3 py-2 rounded bg-gray-800 border border-gray-700" />
+      </div>
+      <button type="submit" class="w-full py-2 bg-green-600 hover:bg-green-700 rounded">Add Streamer</button>
+    </form>
+
+    <ul id="streamerList" class="space-y-2"></ul>
+  </div>
+
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+    import { getFirestore, collection, addDoc, getDocs, deleteDoc, doc, updateDoc } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+    import { getAuth, signInWithEmailAndPassword, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
+      authDomain: "team-sign-up-b5646.firebaseapp.com",
+      projectId: "team-sign-up-b5646",
+      storageBucket: "team-sign-up-b5646.firebasestorage.app",
+      messagingSenderId: "951471144681",
+      appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getFirestore(app);
+    const auth = getAuth();
+
+    const loginDiv = document.getElementById('loginDiv');
+    const adminPanel = document.getElementById('adminPanel');
+    const loginBtn = document.getElementById('loginBtn');
+    const logoutBtn = document.getElementById('logoutBtn');
+
+    loginBtn.addEventListener('click', () => {
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+      signInWithEmailAndPassword(auth, email, password).catch(err => alert(err.message));
+    });
+
+    logoutBtn.addEventListener('click', () => signOut(auth));
+
+    onAuthStateChanged(auth, user => {
+      if (user) {
+        loginDiv.classList.add('hidden');
+        adminPanel.classList.remove('hidden');
+        loadStreamers();
+      } else {
+        loginDiv.classList.remove('hidden');
+        adminPanel.classList.add('hidden');
+      }
+    });
+
+    document.getElementById('addStreamerForm').addEventListener('submit', async e => {
+      e.preventDefault();
+      const displayName = document.getElementById('displayName').value.trim();
+      const handle = document.getElementById('twitchHandle').value.trim();
+      const team = document.getElementById('team').value.trim();
+      if (!displayName || !handle) return;
+      const avatarUrl = `https://decapi.me/twitch/avatar/${encodeURIComponent(handle)}`;
+      await addDoc(collection(db, 'streamers'), { displayName, twitchHandle: handle, team, avatarUrl, approved: true });
+      e.target.reset();
+      loadStreamers();
+    });
+
+    async function loadStreamers() {
+      const list = document.getElementById('streamerList');
+      list.innerHTML = '';
+      const snap = await getDocs(collection(db, 'streamers'));
+      snap.forEach(docSnap => {
+        const data = docSnap.data();
+        const li = document.createElement('li');
+        li.className = 'bg-gray-800 p-3 rounded flex justify-between items-center';
+        li.innerHTML = `
+          <span><strong>${data.displayName}</strong> - ${data.twitchHandle} ${data.team ? `(${data.team})` : ''}</span>
+          <span>
+            <button data-id="${docSnap.id}" data-approved="${data.approved}" class="approve bg-blue-600 hover:bg-blue-700 px-2 py-1 rounded mr-2">${data.approved ? 'Unapprove' : 'Approve'}</button>
+            <button data-id="${docSnap.id}" class="delete bg-red-600 hover:bg-red-700 px-2 py-1 rounded">Delete</button>
+          </span>
+        `;
+        list.appendChild(li);
+      });
+
+      list.querySelectorAll('.delete').forEach(btn => btn.addEventListener('click', async e => {
+        const id = e.target.dataset.id;
+        await deleteDoc(doc(db, 'streamers', id));
+        loadStreamers();
+      }));
+
+      list.querySelectorAll('.approve').forEach(btn => btn.addEventListener('click', async e => {
+        const id = e.target.dataset.id;
+        const approved = e.target.dataset.approved === 'true';
+        await updateDoc(doc(db, 'streamers', id), { approved: !approved });
+        loadStreamers();
+      }));
+    }
+  </script>
+</body>
+</html>

--- a/StreamersSubmit.html
+++ b/StreamersSubmit.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Submit Streamer</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+        const panel = document.getElementById('live-teams-panel');
+        if (panel) panel.style.top = '9rem';
+      }
+    });
+  </script>
+
+  <div class="max-w-md mx-auto mt-10 p-6 bg-gray-800 rounded-lg shadow">
+    <h1 class="text-2xl font-bold text-center mb-4">Submit a Streamer</h1>
+    <form id="submitForm" class="space-y-4">
+      <div>
+        <label class="block text-sm mb-1">Display Name</label>
+        <input id="displayName" type="text" required class="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600" />
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Twitch Handle</label>
+        <input id="twitchHandle" type="text" required class="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600" />
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Team (optional)</label>
+        <input id="team" type="text" class="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600" />
+      </div>
+      <button type="submit" class="w-full py-2 bg-green-600 hover:bg-green-700 rounded">Submit for Approval</button>
+    </form>
+    <p id="status" class="hidden text-center mt-4 text-green-400">Streamer submitted! Pending admin approval.</p>
+  </div>
+
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+    import { getFirestore, collection, addDoc } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
+      authDomain: "team-sign-up-b5646.firebaseapp.com",
+      projectId: "team-sign-up-b5646",
+      storageBucket: "team-sign-up-b5646.firebasestorage.app",
+      messagingSenderId: "951471144681",
+      appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getFirestore(app);
+
+    document.getElementById('submitForm').addEventListener('submit', async e => {
+      e.preventDefault();
+      const displayName = document.getElementById('displayName').value.trim();
+      const handle = document.getElementById('twitchHandle').value.trim();
+      const team = document.getElementById('team').value.trim();
+      if (!displayName || !handle) return;
+      const avatarUrl = `https://decapi.me/twitch/avatar/${encodeURIComponent(handle)}`;
+      await addDoc(collection(db, 'streamers'), { displayName, twitchHandle: handle, team, avatarUrl, approved: false });
+      e.target.reset();
+      document.getElementById('status').classList.remove('hidden');
+    });
+  </script>
+</body>
+</html>

--- a/TeamSignUp.html
+++ b/TeamSignUp.html
@@ -66,9 +66,9 @@
       apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
       authDomain: "team-sign-up-b5646.firebaseapp.com",
       projectId: "team-sign-up-b5646",
-      storageBucket: "team-sign-up-b5646.appspot.com",
+      storageBucket: "team-sign-up-b5646.firebasestorage.app",
       messagingSenderId: "951471144681",
-      appId: "1:951471144681:web:d150b047ed0e93a2d9ba78"
+      appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
     };
 
     const app = initializeApp(firebaseConfig);

--- a/nav.html
+++ b/nav.html
@@ -10,6 +10,9 @@
             <li><a href="UpcomingEvents.html" class="hover:text-blue-400 transition">Upcoming Events</a></li>
             <!-- Replaced old Draft Sign-Up link with Team SignUp page -->
             <li><a href="TeamSignUp.html" class="hover:text-blue-400 transition">Team SignUp</a></li>
+            <li><a href="Streamers.html" class="hover:text-blue-400 transition">Streamers</a></li>
+            <li><a href="StreamersSubmit.html" class="hover:text-blue-400 transition">Submit Streamer</a></li>
+            <li><a href="StreamersAdmin.html" class="hover:text-blue-400 transition">Streamers Admin</a></li>
 
             <!-- <li><a href="TeamBuilder.html" class="hover:text-blue-400 transition">Create Team</a></li> -->
             <!-- <li><a href="MontageBay.html" class="hover:text-blue-400 transition">Montage Bay</a></li> -->


### PR DESCRIPTION
## Summary
- Create a public Streamers page that pulls approved streamers from Firestore and displays them in card layouts
- Add an admin-only management page using Firebase Auth for adding, approving, and deleting streamers
- Link the new Streamers page in the site navigation
- Sync Firebase config values across the project with the latest credentials
- Surface a helper message when no streamers are approved and link to the Streamers Admin panel from navigation
- Introduce a public submission form that lets anyone suggest a streamer for admin approval

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892282ff670832a865b2e02e7dd5958