### PR TITLE
Add default streamer avatars and backfill script

### DIFF
--- a/Streamers.html
+++ b/Streamers.html
@@ -60,10 +60,13 @@
       }
       snap.forEach(doc => {
         const data = doc.data();
+        if (!data.avatarUrl || data.avatarUrl.trim() === '') {
+          data.avatarUrl = `https://decapi.me/twitch/avatar/${data.twitchHandle}`;
+        }
         const card = document.createElement('div');
         card.className = 'bg-gray-800 rounded-lg overflow-hidden shadow-lg';
         card.innerHTML = `
-          <img src="${data.avatarUrl || 'https://placehold.co/300x200'}" alt="${data.displayName}" class="w-full h-48 object-cover">
+          <img src="${data.avatarUrl}" alt="${data.displayName}" class="w-full h-48 object-cover" onerror="this.onerror=null;this.src='Twin.jpg';">
           <div class="p-4">
             <h2 class="text-xl font-semibold mb-2">${data.displayName}</h2>
             ${data.team ? `<p class=\"text-sm mb-2\">Team: ${data.team}</p>` : ''}

--- a/updateMissingAvatarUrls.js
+++ b/updateMissingAvatarUrls.js
@@ -1,0 +1,34 @@
+// One-time script to backfill missing avatarUrl fields in Firestore.
+// Usage: set GOOGLE_APPLICATION_CREDENTIALS to a service account JSON file
+// and run `node updateMissingAvatarUrls.js`.
+
+import { initializeApp, applicationDefault } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+initializeApp({
+  credential: applicationDefault(),
+});
+
+const db = getFirestore();
+
+async function updateAvatars() {
+  const snap = await db.collection("streamers").get();
+  const updates = [];
+
+  snap.forEach((doc) => {
+    const data = doc.data();
+    if (!data.avatarUrl || data.avatarUrl.trim() === "") {
+      const avatarUrl = `https://decapi.me/twitch/avatar/${data.twitchHandle}`;
+      updates.push(doc.ref.update({ avatarUrl }));
+      console.log(`Updated ${doc.id} -> ${avatarUrl}`);
+    }
+  });
+
+  await Promise.all(updates);
+  console.log("Avatar URL backfill complete.");
+}
+
+updateAvatars().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- ensure Streamers page defaults avatarUrl to Twitch decapi endpoint
- show local placeholder image if avatar fails to load
- add script to backfill missing avatarUrl fields in Firestore

## Testing
- `npx prettier --check updateMissingAvatarUrls.js`


------
https://chatgpt.com/codex/tasks/task_e_68928a5119cc832a8129ce13fa00dec4