### PR TITLE
Add streamer bios

### DIFF
--- a/Streamers.html
+++ b/Streamers.html
@@ -66,7 +66,8 @@
           <img src="${data.avatarUrl || 'https://placehold.co/300x200'}" alt="${data.displayName}" class="w-full h-48 object-cover">
           <div class="p-4">
             <h2 class="text-xl font-semibold mb-2">${data.displayName}</h2>
-            ${data.team ? `<p class=\"text-sm mb-2\">Team: ${data.team}</p>` : ''}
+            ${data.team ? `<p class=\"text-sm mb-1\">Team: ${data.team}</p>` : ''}
+            ${data.bio ? `<p class=\"text-sm text-gray-300 mb-2\">${data.bio.length > 100 ? data.bio.substring(0, 100) + '...' : data.bio}</p>` : ''}
             <a href="https://twitch.tv/${data.twitchHandle}" target="_blank" class="text-purple-400 hover:underline">twitch.tv/${data.twitchHandle}</a>
           </div>
         `;

--- a/StreamersAdmin.html
+++ b/StreamersAdmin.html
@@ -46,6 +46,10 @@
         <label class="block text-sm mb-1">Team (optional)</label>
         <input id="team" type="text" class="w-full px-3 py-2 rounded bg-gray-800 border border-gray-700" />
       </div>
+      <div>
+        <label class="block text-sm mb-1">Bio (optional)</label>
+        <textarea id="bio" rows="3" class="w-full px-3 py-2 rounded bg-gray-800 border border-gray-700"></textarea>
+      </div>
       <button type="submit" class="w-full py-2 bg-green-600 hover:bg-green-700 rounded">Add Streamer</button>
     </form>
 
@@ -99,9 +103,10 @@
       const displayName = document.getElementById('displayName').value.trim();
       const handle = document.getElementById('twitchHandle').value.trim();
       const team = document.getElementById('team').value.trim();
+      const bio = document.getElementById('bio').value.trim();
       if (!displayName || !handle) return;
       const avatarUrl = `https://decapi.me/twitch/avatar/${encodeURIComponent(handle)}`;
-      await addDoc(collection(db, 'streamers'), { displayName, twitchHandle: handle, team, avatarUrl, approved: true });
+      await addDoc(collection(db, 'streamers'), { displayName, twitchHandle: handle, team, bio, avatarUrl, approved: true });
       e.target.reset();
       loadStreamers();
     });

--- a/StreamersSubmit.html
+++ b/StreamersSubmit.html
@@ -35,6 +35,10 @@
         <label class="block text-sm mb-1">Team (optional)</label>
         <input id="team" type="text" class="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600" />
       </div>
+      <div>
+        <label class="block text-sm mb-1">Bio (optional)</label>
+        <textarea id="bio" rows="3" class="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600"></textarea>
+      </div>
       <button type="submit" class="w-full py-2 bg-green-600 hover:bg-green-700 rounded">Submit for Approval</button>
     </form>
     <p id="status" class="hidden text-center mt-4 text-green-400">Streamer submitted! Pending admin approval.</p>
@@ -61,9 +65,10 @@
       const displayName = document.getElementById('displayName').value.trim();
       const handle = document.getElementById('twitchHandle').value.trim();
       const team = document.getElementById('team').value.trim();
+      const bio = document.getElementById('bio').value.trim();
       if (!displayName || !handle) return;
       const avatarUrl = `https://decapi.me/twitch/avatar/${encodeURIComponent(handle)}`;
-      await addDoc(collection(db, 'streamers'), { displayName, twitchHandle: handle, team, avatarUrl, approved: false });
+      await addDoc(collection(db, 'streamers'), { displayName, twitchHandle: handle, team, bio, avatarUrl, approved: false });
       e.target.reset();
       document.getElementById('status').classList.remove('hidden');
     });

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,15 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /streamers/{streamerId} {
+      allow read: if resource.data.approved == true;
+      allow create: if request.resource.data.approved == false
+        && request.resource.data.displayName is string
+        && request.resource.data.twitchHandle is string
+        && (!('team' in request.resource.data) || request.resource.data.team is string)
+        && (!('bio' in request.resource.data) || request.resource.data.bio is string)
+        && (!('avatarUrl' in request.resource.data) || request.resource.data.avatarUrl is string);
+      allow update, delete: if request.auth != null;
+    }
+  }
+}

--- a/scripts/backfillBios.js
+++ b/scripts/backfillBios.js
@@ -1,0 +1,36 @@
+// Script to backfill streamer bios in Firestore.
+// Requires firebase-admin package and service account credentials.
+// Usage:
+//   export FIREBASE_SERVICE_ACCOUNT='{"type":...}'
+//   node scripts/backfillBios.js
+
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const serviceAccountJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+if (!serviceAccountJson) {
+  console.error('FIREBASE_SERVICE_ACCOUNT env var is required.');
+  process.exit(1);
+}
+
+initializeApp({ credential: cert(JSON.parse(serviceAccountJson)) });
+const db = getFirestore();
+
+// Map twitchHandle -> bio text
+const bios = {
+  // 'exampleHandle': 'Example bio',
+};
+
+async function run() {
+  for (const [handle, bio] of Object.entries(bios)) {
+    const snap = await db.collection('streamers').where('twitchHandle', '==', handle).get();
+    snap.forEach(doc => doc.ref.update({ bio }));
+  }
+  console.log('Backfill complete');
+  process.exit(0);
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- allow admins and users to include an optional bio when adding streamers
- surface streamer bios on the Streamers page and enable Firestore to store the field
- add script and security rules updates for backfilling bios

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68928a572868832a8eb0fef93d1d3d51