### PR TITLE
Rebrand site to Tribes Professional League

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Project Tribes
+# Tribes Professional League
 
 This repository contains a collection of static HTML pages for the community around **Tribes 3: Rivals**. Each page focuses on tournament information, team rosters, or related utilities. All files are static—no backend server is required.
 
 ## Pages
 
-- **TribesRivalsTeamsDashboard.html** – Main dashboard linking to individual team pages, streaming links, and historical information.
+- **TPLTeamsDashboard.html** – Main dashboard linking to individual team pages, streaming links, and historical information.
 - **TournamentManager.html** – React-based page for managing tournaments and importing sign-up data.
 - **TribesScrimWatcher.html** – Utility for previewing scrimmage matchups and team rosters. Includes a chat box powered by Twitch embeds that appears alongside the match streams.
 - **TwitchFeedDisplays.html** – Layout for watching multiple Twitch streams at once.
@@ -23,7 +23,7 @@ This repository contains a collection of static HTML pages for the community aro
 
 You can open these pages directly:
 
-- [Tribes Rivals Dashboard](TribesRivalsTeamsDashboard.html)
+- [Tribes Professional League Dashboard](TPLTeamsDashboard.html)
 - [Scrim Watcher](TribesScrimWatcher.html)
 - [Tournament Manager](TournamentManager.html)
 - [Twitch Feeds](TwitchFeedDisplays.html)
@@ -38,7 +38,7 @@ You can open these pages directly:
 
 ## Usage
 
-Open `TribesRivalsTeamsDashboard.html` in your browser to access the main dashboard. External team or stream links on each page open in new tabs. Each team page provides roster info and may link to Twitch or YouTube streams.
+Open `TPLTeamsDashboard.html` in your browser to access the main dashboard. External team or stream links on each page open in new tabs. Each team page provides roster info and may link to Twitch or YouTube streams.
 
 All pages can be opened locally in your browser. The **Create Team** and **Montage Bay** pages save data using `localStorage`.
 ## Shared Navigation
@@ -50,7 +50,7 @@ The main navigation menu is stored in `nav.html`. Each page dynamically loads th
 Certain pages include a "Sign in with Twitch" button. Logging in stores your access token in `localStorage` so the site can personalize Twitch feeds. The login uses the [Twitch OAuth implicit flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#implicit-code-flow).
 When signed in, the main dashboard shows your Twitch username.
 
-In the navigation bar a **Live Teams** button appears after you sign in with Twitch. Clicking the button toggles a side menu that slides in from the left. On the teams dashboard the menu is positioned just below the "Tribes Rivals Dashboard" heading and above the "Select a Team" section. Clicking anywhere outside the menu closes it. Because the site queries the Twitch API using your token, being logged in is required for this list to populate.
+In the navigation bar a **Live Teams** button appears after you sign in with Twitch. Clicking the button toggles a side menu that slides in from the left. On the teams dashboard the menu is positioned just below the "Tribes Professional League Dashboard" heading and above the "Select a Team" section. Clicking anywhere outside the menu closes it. Because the site queries the Twitch API using your token, being logged in is required for this list to populate.
 
 The teams dashboard also checks each roster's streamers against Twitch and highlights teams that are currently live.
 
@@ -69,4 +69,4 @@ The `TeamSignUp.html` page uses [Firebase Firestore](https://firebase.google.com
 
 ## Credits
 
-© 2025 Tribes Rivals community. Individual team pages contain their respective credits.
+© 2025 Tribes Professional League community. Individual team pages contain their respective credits.

--- a/TPLTeamsDashboard.html
+++ b/TPLTeamsDashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tribes Rivals Dashboard</title>
+    <title>Tribes Professional League Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="oauth.js"></script>
     <style>
@@ -78,8 +78,8 @@
     <!-- Header -->
     <header class="bg-gray-800 py-6 shadow-lg">
         <div class="container mx-auto px-4 text-center">
-            <h1 class="text-4xl md:text-5xl font-bold text-blue-400">Tribes Rivals Dashboard</h1>
-            <p class="mt-2 text-lg text-gray-300">Your hub for all Tribes Rivals teams and history</p>
+            <h1 class="text-4xl md:text-5xl font-bold text-blue-400">Tribes Professional League Dashboard</h1>
+            <p class="mt-2 text-lg text-gray-300">Your hub for all Tribes Professional League teams and history</p>
         </div>
     </header>
 
@@ -230,9 +230,9 @@
             </div>
             <!-- DeadStop -->
             <div class="team-card bg-gray-800 rounded-lg overflow-hidden shadow-lg">
-                <a href="https://t24085.github.io/ProjectTribes/TeamDS.html">
+                <a href="https://t24085.github.io/TribesProfessionalLeague/TeamDS.html">
 
-                    <img src="https://github.com/T24085/ProjectTribes/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_05_19%20PM.png?raw=true" alt="DeadStop team logo with calming tribal design" class="w-full h-48 object-cover">
+                    <img src="https://github.com/T24085/TribesProfessionalLeague/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_05_19%20PM.png?raw=true" alt="DeadStop team logo with calming tribal design" class="w-full h-48 object-cover">
 
                 </a>
                 <div class="p-4 text-center">
@@ -347,8 +347,8 @@
     <!-- Footer -->
     <footer class="bg-gray-800 py-6">
         <div class="container mx-auto px-4 text-center">
-            <p class="text-gray-400">© 2025 Tribes Rivals Dashboard. All rights reserved.</p>
-            <p class="text-gray-400">Built for the Tribes Rivals community.</p>
+            <p class="text-gray-400">© 2025 Tribes Professional League Dashboard. All rights reserved.</p>
+            <p class="text-gray-400">Built for the Tribes Professional League community.</p>
         </div>
     </footer>
 

--- a/TeamDPRK.html
+++ b/TeamDPRK.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>[DPRK] Tribes Rivals Team</title>
+    <title>[DPRK] TPL Team</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -227,7 +227,7 @@
 <body>
     <header>
         <img src="https://github.com/T24085/TeamDPRK/blob/main/TeamDPRKLogo3.png?raw=true" alt="DPRK Logo">
-        <h1>[DPRK] Tribes Rivals</h1>
+        <h1>[DPRK] TPL</h1>
     </header>
     <nav>
         <a href="#team-intro">Team Intro</a>
@@ -240,8 +240,8 @@
     <div class="container">
         <div class="team-intro" id="team-intro">
             <h2>Team Introduction</h2>
-            <p>Welcome to [DPRK] Tribes Rivals, a formidable force in the competitive Tribes Rivals community, built on a foundation of skill, strategy, and unwavering dedication. Established with a vision to dominate the battlefield, our team is led by a dynamic leadership trio that drives our success. Glem, our esteemed Leader, brings versatility to the team with a flex role, most often excelling as a Medium Offense player, adapting to any situation with precision and tactical brilliance. CheezeCaeke, our Co-Leader, oversees operations with a steady hand, specializing as a HOF Heavy On Flag player, while ColonelFatso, our Captain, commands the frontline as a Capper, ensuring our strategies are executed flawlessly.</p>
-            <p>Our core principles revolve around teamwork, discipline, and continuous improvement. We foster an environment where every player’s contribution is valued, from the strategic minds to the agile defenders. Our roster is a blend of seasoned veterans and rising stars, each bringing unique strengths to the table. Meet our key players: Nemesis, a skilled Capper who dominates flag captures; Rhino, a stalwart Light Defense specialist; Halogen, another Light Defense powerhouse; and Panda, our Heavy Offense enforcer. Together, we uphold a commitment to excellence, pushing the boundaries of competitive play while building a legacy of victory in the Tribes Rivals arena.</p>
+            <p>Welcome to [DPRK] TPL, a formidable force in the competitive Tribes Professional League community, built on a foundation of skill, strategy, and unwavering dedication. Established with a vision to dominate the battlefield, our team is led by a dynamic leadership trio that drives our success. Glem, our esteemed Leader, brings versatility to the team with a flex role, most often excelling as a Medium Offense player, adapting to any situation with precision and tactical brilliance. CheezeCaeke, our Co-Leader, oversees operations with a steady hand, specializing as a HOF Heavy On Flag player, while ColonelFatso, our Captain, commands the frontline as a Capper, ensuring our strategies are executed flawlessly.</p>
+            <p>Our core principles revolve around teamwork, discipline, and continuous improvement. We foster an environment where every player’s contribution is valued, from the strategic minds to the agile defenders. Our roster is a blend of seasoned veterans and rising stars, each bringing unique strengths to the table. Meet our key players: Nemesis, a skilled Capper who dominates flag captures; Rhino, a stalwart Light Defense specialist; Halogen, another Light Defense powerhouse; and Panda, our Heavy Offense enforcer. Together, we uphold a commitment to excellence, pushing the boundaries of competitive play while building a legacy of victory in the Tribes Professional League arena.</p>
         </div>
         <div class="featured-videos" id="featured-videos">
             <h2>Featured Videos</h2>
@@ -398,12 +398,12 @@
                     <th>Result</th>
                 </tr>
                 <tr>
-                    <td>Tribes Rivals FatBoys of Summer Draft</td>
+                    <td>Tribes Professional League FatBoys of Summer Draft</td>
                     <td>2025</td>
                     <td>2nd Place</td>
                 </tr>
                 <tr>
-                    <td>Tribes Rivals March Draft</td>
+                    <td>Tribes Professional League March Draft</td>
                     <td>2025</td>
                     <td>2nd Place</td>
                 </tr>
@@ -416,7 +416,7 @@
         </div>
     </div>
     <footer>
-        <p>© 2025 [DPRK] Tribes Rivals. All rights reserved.</p>
+        <p>© 2025 [DPRK] Tribes Professional League. All rights reserved.</p>
         <img src="https://github.com/T24085/TeamDPRK/blob/main/DPRKLOGO.png?raw=true" alt="DPRK Logo">
     </footer>
 </body>

--- a/TeamDS.html
+++ b/TeamDS.html
@@ -64,7 +64,7 @@
         /* Tribal tattoo-like pattern background */
         .gradient-bg {
 
-            background: linear-gradient(rgba(0,0,0, 0.2), rgba(0,0,0, 0.2)), url('https://github.com/T24085/ProjectTribes/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_05_19%20PM.png?raw=true');
+            background: linear-gradient(rgba(0,0,0, 0.2), rgba(0,0,0, 0.2)), url('https://github.com/T24085/TribesProfessionalLeague/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_05_19%20PM.png?raw=true');
 
             background-size: 50px;
             background-repeat: repeat;
@@ -84,7 +84,7 @@
         /* Parallax background styles */
         .parallax-hero {
 
-            background-image: url('https://github.com/T24085/ProjectTribes/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_12_46%20PM.png?raw=true');
+            background-image: url('https://github.com/T24085/TribesProfessionalLeague/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_12_46%20PM.png?raw=true');
 
             background-attachment: fixed;
             background-position: center;
@@ -163,7 +163,7 @@
             <div class="flex items-center">
                 <!-- Team Logo -->
 
-                <img src="https://github.com/T24085/ProjectTribes/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_05_19%20PM.png?raw=true" alt="DeadStop [DS] Logo" class="w-16 h-16 rounded-full border-2 border-gray-500">
+                <img src="https://github.com/T24085/TribesProfessionalLeague/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_05_19%20PM.png?raw=true" alt="DeadStop [DS] Logo" class="w-16 h-16 rounded-full border-2 border-gray-500">
 
                 <h1 class="ml-4 text-3xl font-extrabold glow-text">DeadStop [DS]</h1>
             </div>

--- a/TournamentBrackets.html
+++ b/TournamentBrackets.html
@@ -1511,7 +1511,7 @@
             <h2 className="text-2xl font-bold mb-4">Related Pages</h2>
             <div className="flex gap-4">
               <a
-                href="https://t24085.github.io/ProjectTribes/DraftSignUp.html"
+                href="https://t24085.github.io/TribesProfessionalLeague/DraftSignUp.html"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
@@ -1519,7 +1519,7 @@
                 Draft Sign-Up Sheet
               </a>
               <a
-                href="https://t24085.github.io/ProjectTribes/TournamentManager.html"
+                href="https://t24085.github.io/TribesProfessionalLeague/TournamentManager.html"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tribes Rivals Scrim Watcher</title>
+    <title>Tribes Professional League Scrim Watcher</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="oauth.js"></script>
     <style>
@@ -129,7 +129,7 @@
             });
     </script>
     <header class="text-center py-6">
-        <h1 class="text-4xl font-bold text-violet-400">Tribes Rivals Scrim Watcher</h1>
+        <h1 class="text-4xl font-bold text-violet-400">Tribes Professional League Scrim Watcher</h1>
     </header>
     <div id="bg-left"></div>
     <div id="bg-right"></div>
@@ -263,7 +263,7 @@
             },
             "DeadStop": {
 
-                logo: "https://github.com/T24085/ProjectTribes/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_05_19%20PM.png?raw=true",
+                logo: "https://github.com/T24085/TribesProfessionalLeague/blob/main/ChatGPT%20Image%20Jul%2029,%202025,%2006_05_19%20PM.png?raw=true",
 
                 roster: "Captain: Blitz\nCore: apc, Hosh, Luna, Rock, Rell, Iinferno, Makasuro, CheesyDean, ContingencyPlan\nBench: Nykie4Life",
                 streams: [

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -339,9 +339,9 @@
         <button id="toggle-live-btn" onclick="toggleLiveOnly()">Show Only Live</button>
       </div>
       <div class="donation-section">
-        <p>Support the Tribes 3: Rivals Multi Display!</p>
+        <p>Support the Tribes Professional League Multi Display!</p>
         <form action="https://www.paypal.com/ncp/payment/BC4EF2QC9T5GA" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">
-          <input class="pp-BC4EF2QC9T5GA" type="submit" value="Support the Tribes Rivals Multi Display" />
+          <input class="pp-BC4EF2QC9T5GA" type="submit" value="Support the Tribes Professional League Multi Display" />
           <img src="https://www.paypalobjects.com/images/Debit_Credit_APM.svg" alt="cards" />
           <section style="font-size: 0.75rem;"> Powered by <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"/></section>
         </form>

--- a/TwitchFeedMobile.html
+++ b/TwitchFeedMobile.html
@@ -295,7 +295,7 @@
   <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
     <div class="container mx-auto">
       <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
-        <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
+        <li><a href="TPLTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
         <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
         <li><a href="TournamentManager.html" class="hover:text-blue-400 transition">Tournament Manager</a></li>
         <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>
@@ -329,9 +329,9 @@
         </div>
       </div>
       <div class="donation-section">
-        <p>Support the Tribes 3: Rivals Tournament!</p>
+        <p>Support the Tribes Professional League Tournament!</p>
         <form action="https://www.paypal.com/ncp/payment/BC4EF2QC9T5GA" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">
-          <input class="pp-BC4EF2QC9T5GA" type="submit" value="Support the Tribes Rivals Multi Display" />
+          <input class="pp-BC4EF2QC9T5GA" type="submit" value="Support the Tribes Professional League Multi Display" />
           <img src="https://www.paypalobjects.com/images/Debit_Credit_APM.svg" alt="cards" />
           <section style="font-size: 0.75rem;"> Powered by <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"/></section>
         </form>

--- a/announcements.json
+++ b/announcements.json
@@ -1,6 +1,6 @@
 [
   {
-    "message": "Welcome to Project Tribes!",
+    "message": "Welcome to Tribes Professional League!",
     "startTime": "2020-01-01T00:00:00Z",
     "endTime": "2030-01-01T00:00:00Z"
   }

--- a/nav.html
+++ b/nav.html
@@ -2,7 +2,7 @@
 <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
     <div class="container mx-auto relative">
         <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
-            <li><a href="TribesRivalsTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
+            <li><a href="TPLTeamsDashboard.html" class="hover:text-blue-400 transition">Teams</a></li>
             <li><a href="TribesScrimWatcher.html" class="hover:text-blue-400 transition">Scrim Watcher</a></li>
             <li><a href="TournamentBrackets.html" class="hover:text-blue-400 transition">Tournament Brackets</a></li>
             <li><a href="TwitchFeedDisplays.html" class="hover:text-blue-400 transition">Twitch Feeds</a></li>

--- a/oauth.js
+++ b/oauth.js
@@ -1,6 +1,6 @@
 (function(){
   const CLIENT_ID = 'meabi1n42pccff5rz9ujpno7ky9vlt';
-  const REDIRECT_URI = 'https://t24085.github.io/ProjectTribes/TribesRivalsTeamsDashboard.html';
+  const REDIRECT_URI = 'https://t24085.github.io/TribesProfessionalLeague/TPLTeamsDashboard.html';
   const STORAGE_KEY = 'twitch_token';
 
   const TEAM_STREAMS = {


### PR DESCRIPTION
## Summary
- rename dashboard and navigation to `TPLTeamsDashboard` for Tribes Professional League
- update OAuth redirect, announcements, and team pages to new league name
- refresh support messaging and internal links to use new TPL domain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ce204334832aa467e93f439d075b