### PR TITLE
Add season structures and league management UI

### DIFF
--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>League Manager</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+      }
+    });
+  </script>
+
+  <div class="w-full max-w-4xl p-4">
+    <h1 class="text-2xl font-bold text-center mb-4">League Manager</h1>
+    <div class="flex flex-col md:flex-row gap-4 justify-center mb-6">
+      <div>
+        <label class="block text-sm mb-1">Season</label>
+        <select id="lmSeason" class="px-3 py-2 rounded-md bg-gray-700 border border-gray-600"></select>
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Division</label>
+        <select id="lmDivision" class="px-3 py-2 rounded-md bg-gray-700 border border-gray-600"></select>
+      </div>
+    </div>
+
+    <div>
+      <h2 class="text-xl font-semibold mb-2">Standings</h2>
+      <table id="standingsTable" class="min-w-full text-left"></table>
+    </div>
+
+    <div class="mt-6">
+      <h2 class="text-xl font-semibold mb-2">Schedule</h2>
+      <div id="scheduleContainer"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    let seasonsIndex = [];
+    let currentSeasonData = null;
+
+    async function loadSeasons() {
+      const res = await fetch('seasons/index.json');
+      seasonsIndex = await res.json();
+      const seasonSelect = document.getElementById('lmSeason');
+      seasonsIndex.forEach(season => {
+        const opt = document.createElement('option');
+        opt.value = season.id;
+        opt.textContent = `Season ${season.id}`;
+        seasonSelect.appendChild(opt);
+      });
+      const active = seasonsIndex.filter(s => s.active).pop() || seasonsIndex[seasonsIndex.length - 1];
+      seasonSelect.value = active.id;
+      await loadSeasonData(active.id);
+    }
+
+    async function loadSeasonData(id) {
+      const seasonInfo = seasonsIndex.find(s => s.id == id);
+      if (!seasonInfo) return;
+      const res = await fetch(`seasons/${seasonInfo.file}`);
+      currentSeasonData = await res.json();
+      const divisionSelect = document.getElementById('lmDivision');
+      divisionSelect.innerHTML = '';
+      Object.keys(currentSeasonData.divisions).forEach(div => {
+        const opt = document.createElement('option');
+        opt.value = div;
+        opt.textContent = div;
+        divisionSelect.appendChild(opt);
+      });
+      divisionSelect.value = Object.keys(currentSeasonData.divisions)[0];
+      renderDivision();
+    }
+
+    function renderDivision() {
+      const divKey = document.getElementById('lmDivision').value;
+      const divData = currentSeasonData.divisions[divKey];
+      renderStandings(divData.standings);
+      renderSchedule(divData.schedule);
+    }
+
+    function renderStandings(rows) {
+      const table = document.getElementById('standingsTable');
+      table.innerHTML = '';
+      const header = document.createElement('tr');
+      header.innerHTML = '<th class="px-2">Team</th><th class="px-2">W</th><th class="px-2">L</th>';
+      table.appendChild(header);
+      rows.forEach(r => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td class="px-2">${r.team}</td><td class="px-2">${r.wins}</td><td class="px-2">${r.losses}</td>`;
+        table.appendChild(tr);
+      });
+    }
+
+    function renderSchedule(weeks) {
+      const container = document.getElementById('scheduleContainer');
+      container.innerHTML = '';
+      weeks.forEach(w => {
+        const div = document.createElement('div');
+        div.className = 'mb-4';
+        const title = document.createElement('h3');
+        title.className = 'font-semibold mb-1';
+        title.textContent = `Week ${w.week}`;
+        div.appendChild(title);
+        const ul = document.createElement('ul');
+        w.matches.forEach(m => {
+          const li = document.createElement('li');
+          li.textContent = `${m.date}: ${m.away} @ ${m.home}`;
+          ul.appendChild(li);
+        });
+        div.appendChild(ul);
+        container.appendChild(div);
+      });
+    }
+
+    document.getElementById('lmSeason').addEventListener('change', e => loadSeasonData(e.target.value));
+    document.getElementById('lmDivision').addEventListener('change', renderDivision);
+
+    loadSeasons();
+  </script>
+</body>
+</html>

--- a/TeamSignUp.html
+++ b/TeamSignUp.html
@@ -37,6 +37,16 @@
           class="w-full px-3 py-2 rounded-md bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500" />
       </div>
 
+      <div>
+        <label class="block text-sm mb-1">Season</label>
+        <select id="seasonSelect" required class="w-full px-3 py-2 rounded-md bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"></select>
+      </div>
+
+      <div>
+        <label class="block text-sm mb-1">Division</label>
+        <select id="divisionSelect" required class="w-full px-3 py-2 rounded-md bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"></select>
+      </div>
+
       <div id="playersContainer" class="space-y-2"></div>
       <button type="button" id="addPlayerBtn"
         class="w-full py-1 rounded-md bg-gray-700 hover:bg-gray-600">Add Player</button>
@@ -78,7 +88,10 @@
     const output = document.getElementById("teamOutput");
     const playersContainer = document.getElementById("playersContainer");
     const addPlayerBtn = document.getElementById("addPlayerBtn");
+    const seasonSelect = document.getElementById('seasonSelect');
+    const divisionSelect = document.getElementById('divisionSelect');
     let playerCount = 0;
+    let seasonsIndex = [];
 
     function addPlayerRow(name = "", twitch = "") {
       if (playerCount >= 7) return;
@@ -95,6 +108,38 @@
     addPlayerBtn.addEventListener("click", () => addPlayerRow());
     document.addEventListener("DOMContentLoaded", () => addPlayerRow());
 
+    async function loadSeasons() {
+      const res = await fetch('seasons/index.json');
+      seasonsIndex = await res.json();
+      seasonSelect.innerHTML = '';
+      seasonsIndex.forEach(season => {
+        const opt = document.createElement('option');
+        opt.value = season.id;
+        opt.textContent = `Season ${season.id}`;
+        seasonSelect.appendChild(opt);
+      });
+      const active = seasonsIndex.filter(s => s.active).pop() || seasonsIndex[seasonsIndex.length - 1];
+      seasonSelect.value = active.id;
+      await loadDivisions(active.id);
+    }
+
+    async function loadDivisions(id) {
+      const info = seasonsIndex.find(s => s.id == id);
+      if (!info) return;
+      const res = await fetch(`seasons/${info.file}`);
+      const data = await res.json();
+      divisionSelect.innerHTML = '';
+      Object.keys(data.divisions).forEach(div => {
+        const opt = document.createElement('option');
+        opt.value = div;
+        opt.textContent = div;
+        divisionSelect.appendChild(opt);
+      });
+    }
+
+    seasonSelect.addEventListener('change', e => loadDivisions(e.target.value));
+    loadSeasons();
+
     async function loadTeams() {
       output.innerHTML = "";
       const snapshot = await getDocs(collection(db, "teams"));
@@ -104,7 +149,7 @@
         li.className = "bg-gray-700 p-2 rounded-md";
         const players = (data.players || []).map(p => p.name).join(', ');
         const bench = (data.benchPlayers || []).join(', ');
-        li.innerHTML = `<strong>${data.teamName} [${data.teamTag}]</strong><br>Players: ${players}${bench ? `<br>Bench: ${bench}` : ''}`;
+        li.innerHTML = `<strong>${data.teamName} [${data.teamTag}]</strong> - Season ${data.season} ${data.division}<br>Players: ${players}${bench ? `<br>Bench: ${bench}` : ''}`;
         output.appendChild(li);
       });
     }
@@ -113,6 +158,8 @@
       e.preventDefault();
       const teamName = document.getElementById("teamName").value.trim();
       const teamTag = document.getElementById("teamTag").value.trim();
+      const season = parseInt(seasonSelect.value, 10);
+      const division = divisionSelect.value;
       const benchPlayers = document.getElementById("benchPlayers").value.trim().split(',').map(p => p.trim()).filter(Boolean);
       const players = Array.from(playersContainer.querySelectorAll('.player-row')).map(row => {
         const inputs = row.querySelectorAll('input');
@@ -121,12 +168,13 @@
         if (!name) return null;
         return { name, twitch };
       }).filter(Boolean);
-      if (!teamName || !teamTag || players.length === 0) return;
-      await addDoc(collection(db, "teams"), { teamName, teamTag, players, benchPlayers });
+      if (!teamName || !teamTag || players.length === 0 || !division || isNaN(season)) return;
+      await addDoc(collection(db, "teams"), { teamName, teamTag, season, division, players, benchPlayers });
       form.reset();
       playersContainer.innerHTML = '';
       playerCount = 0;
       addPlayerRow();
+      loadDivisions(seasonSelect.value);
       loadTeams();
     });
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,5 +11,16 @@ service cloud.firestore {
         && (!('avatarUrl' in request.resource.data) || request.resource.data.avatarUrl is string);
       allow update, delete: if request.auth != null;
     }
+
+    match /teams/{teamId} {
+      allow read: if true;
+      allow create: if
+        request.resource.data.teamName is string &&
+        request.resource.data.teamTag is string &&
+        request.resource.data.season is int &&
+        request.resource.data.division is string &&
+        request.resource.data.division in ['TPL-O', 'TPL-IM', 'TPL-I'];
+      allow update, delete: if request.auth != null;
+    }
   }
 }

--- a/nav.html
+++ b/nav.html
@@ -10,6 +10,7 @@
             <li><a href="UpcomingEvents.html" class="hover:text-blue-400 transition">Upcoming Events</a></li>
             <!-- Replaced old Draft Sign-Up link with Team SignUp page -->
             <li><a href="TeamSignUp.html" class="hover:text-blue-400 transition">Team SignUp</a></li>
+            <li><a href="LeagueManager.html" class="hover:text-blue-400 transition">League Manager</a></li>
             <li><a href="Streamers.html" class="hover:text-blue-400 transition">Streamers</a></li>
             <li><a href="StreamersSubmit.html" class="hover:text-blue-400 transition">Submit Streamer</a></li>
             <li><a href="StreamersAdmin.html" class="hover:text-blue-400 transition">Streamers Admin</a></li>

--- a/seasons/index.json
+++ b/seasons/index.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "file": "season1.json", "active": false },
+  { "id": 2, "file": "season2.json", "active": true }
+]

--- a/seasons/season1.json
+++ b/seasons/season1.json
@@ -1,0 +1,29 @@
+{
+  "season": 1,
+  "divisions": {
+    "TPL-O": {
+      "standings": [
+        { "team": "Team Alpha", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Alpha", "away": "Team Beta", "date": "2025-09-01" } ] }
+      ]
+    },
+    "TPL-IM": {
+      "standings": [
+        { "team": "Team Beta", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Gamma", "away": "Team Delta", "date": "2025-09-02" } ] }
+      ]
+    },
+    "TPL-I": {
+      "standings": [
+        { "team": "Team Gamma", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Epsilon", "away": "Team Zeta", "date": "2025-09-03" } ] }
+      ]
+    }
+  }
+}

--- a/seasons/season2.json
+++ b/seasons/season2.json
@@ -1,0 +1,29 @@
+{
+  "season": 2,
+  "divisions": {
+    "TPL-O": {
+      "standings": [
+        { "team": "Team Omega", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Omega", "away": "Team Sigma", "date": "2026-09-01" } ] }
+      ]
+    },
+    "TPL-IM": {
+      "standings": [
+        { "team": "Team Sigma", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Tau", "away": "Team Upsilon", "date": "2026-09-02" } ] }
+      ]
+    },
+    "TPL-I": {
+      "standings": [
+        { "team": "Team Tau", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Phi", "away": "Team Chi", "date": "2026-09-03" } ] }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce JSON season definitions with TPL-O, TPL-IM and TPL-I divisions
- add LeagueManager page to browse seasons, standings and schedules
- extend team signup and Firestore rules to capture season/division info
- link League Manager in navigation

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ce7eb3ec832a8f7a2736c7b57ef6