### PR TITLE
Add season structures and league management UI

### DIFF
--- a/LeagueAdmin.html
+++ b/LeagueAdmin.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Streamer Admin</title>
+  <title>League Admin</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script src="oauth.js"></script>
 </head>
@@ -29,10 +29,11 @@
 
   <div id="adminPanel" class="hidden container mx-auto px-4 mt-8">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-3xl font-bold">Manage Streamers</h1>
+      <h1 class="text-3xl font-bold">League Admin</h1>
       <button id="logoutBtn" class="py-2 px-4 bg-red-600 hover:bg-red-700 rounded">Logout</button>
     </div>
 
+    <h2 class="text-2xl font-bold mb-4">Manage Streamers</h2>
     <form id="addStreamerForm" class="space-y-4 mb-8">
       <div>
         <label class="block text-sm mb-1">Display Name</label>
@@ -54,11 +55,14 @@
     </form>
 
     <ul id="streamerList" class="space-y-2"></ul>
+
+    <h2 class="text-2xl font-bold mt-12">Manage Teams</h2>
+    <ul id="teamList" class="space-y-2 mt-4"></ul>
   </div>
 
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
-    import { getFirestore, collection, addDoc, getDocs, deleteDoc, doc, updateDoc } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+    import { getFirestore, collection, addDoc, getDocs, deleteDoc, doc, updateDoc, getDoc } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
     import { getAuth, signInWithEmailAndPassword, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
 
     const firebaseConfig = {
@@ -92,6 +96,7 @@
         loginDiv.classList.add('hidden');
         adminPanel.classList.remove('hidden');
         loadStreamers();
+        loadTeams();
       } else {
         loginDiv.classList.remove('hidden');
         adminPanel.classList.add('hidden');
@@ -140,6 +145,64 @@
         const approved = e.target.dataset.approved === 'true';
         await updateDoc(doc(db, 'streamers', id), { approved: !approved });
         loadStreamers();
+      }));
+    }
+
+    async function loadTeams() {
+      const list = document.getElementById('teamList');
+      list.innerHTML = '';
+      const snap = await getDocs(collection(db, 'teams'));
+      snap.forEach(docSnap => {
+        const data = docSnap.data();
+        const li = document.createElement('li');
+        li.className = 'bg-gray-800 p-3 rounded flex justify-between items-center';
+        const players = (data.players || []).map(p => p.name).join(', ');
+        const bench = (data.benchPlayers || []).join(', ');
+        li.innerHTML = `
+          <div>
+            <strong>${data.teamName} [${data.teamTag}]</strong> - Season ${data.season} ${data.division}<br>
+            Players: ${players}${bench ? `<br>Bench: ${bench}` : ''}
+          </div>
+          <span>
+            <button data-id="${docSnap.id}" data-approved="${data.approved}" class="team-approve bg-blue-600 hover:bg-blue-700 px-2 py-1 rounded mr-2">${data.approved ? 'Unapprove' : 'Approve'}</button>
+            <button data-id="${docSnap.id}" class="team-edit bg-yellow-600 hover:bg-yellow-700 px-2 py-1 rounded mr-2">Edit</button>
+            <button data-id="${docSnap.id}" class="team-delete bg-red-600 hover:bg-red-700 px-2 py-1 rounded">Delete</button>
+          </span>`;
+        list.appendChild(li);
+      });
+
+      list.querySelectorAll('.team-delete').forEach(btn => btn.addEventListener('click', async e => {
+        const id = e.target.dataset.id;
+        await deleteDoc(doc(db, 'teams', id));
+        loadTeams();
+      }));
+
+      list.querySelectorAll('.team-approve').forEach(btn => btn.addEventListener('click', async e => {
+        const id = e.target.dataset.id;
+        const approved = e.target.dataset.approved === 'true';
+        await updateDoc(doc(db, 'teams', id), { approved: !approved });
+        loadTeams();
+      }));
+
+      list.querySelectorAll('.team-edit').forEach(btn => btn.addEventListener('click', async e => {
+        const id = e.target.dataset.id;
+        const docRef = doc(db, 'teams', id);
+        const snap = await getDoc(docRef);
+        if (!snap.exists()) return;
+        const data = snap.data();
+        const teamName = prompt('Team Name', data.teamName) || data.teamName;
+        const teamTag = prompt('Team Tag', data.teamTag) || data.teamTag;
+        const season = parseInt(prompt('Season', data.season), 10) || data.season;
+        const division = prompt('Division', data.division) || data.division;
+        const playersText = prompt('Players (Name|Twitch per line)', (data.players || []).map(p => `${p.name}|${p.twitch}`).join('\n')) || '';
+        const players = playersText.split('\n').map(l => {
+          const [name, twitch = ''] = l.split('|').map(s => s.trim());
+          return name ? { name, twitch } : null;
+        }).filter(Boolean);
+        const benchText = prompt('Bench Players (comma separated)', (data.benchPlayers || []).join(', ')) || '';
+        const benchPlayers = benchText.split(',').map(p => p.trim()).filter(Boolean);
+        await updateDoc(docRef, { teamName, teamTag, season, division, players, benchPlayers });
+        loadTeams();
       }));
     }
   </script>

--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>League Manager</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
+  <div id="nav-placeholder"></div>
+  <script>
+    fetch('nav.html').then(r => r.text()).then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+      if (window.twitchOAuth) {
+        twitchOAuth.updateNav();
+        twitchOAuth.initLiveTeamsMenu();
+      }
+    });
+  </script>
+
+  <div class="w-full max-w-4xl p-4">
+    <h1 class="text-2xl font-bold text-center mb-4">League Manager</h1>
+    <div class="flex flex-col md:flex-row gap-4 justify-center mb-6">
+      <div>
+        <label class="block text-sm mb-1">Season</label>
+        <select id="lmSeason" class="px-3 py-2 rounded-md bg-gray-700 border border-gray-600"></select>
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Division</label>
+        <select id="lmDivision" class="px-3 py-2 rounded-md bg-gray-700 border border-gray-600"></select>
+      </div>
+    </div>
+
+    <div>
+      <h2 class="text-xl font-semibold mb-2">Standings</h2>
+      <table id="standingsTable" class="min-w-full text-left"></table>
+    </div>
+
+    <div class="mt-6">
+      <h2 class="text-xl font-semibold mb-2">Schedule</h2>
+      <div id="scheduleContainer"></div>
+    </div>
+  </div>
+
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+    import { getFirestore, collection, getDocs, query, where } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
+      authDomain: "team-sign-up-b5646.firebaseapp.com",
+      projectId: "team-sign-up-b5646",
+      storageBucket: "team-sign-up-b5646.firebasestorage.app",
+      messagingSenderId: "951471144681",
+      appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getFirestore(app);
+
+    let seasonsIndex = [];
+    let currentSeasonData = null;
+
+    async function loadSeasons() {
+      const res = await fetch('seasons/index.json');
+      seasonsIndex = await res.json();
+      const seasonSelect = document.getElementById('lmSeason');
+      seasonsIndex.forEach(season => {
+        const opt = document.createElement('option');
+        opt.value = season.id;
+        opt.textContent = `Season ${season.id}`;
+        seasonSelect.appendChild(opt);
+      });
+      const active = seasonsIndex.filter(s => s.active).pop() || seasonsIndex[seasonsIndex.length - 1];
+      seasonSelect.value = active.id;
+      await loadSeasonData(active.id);
+    }
+
+    async function loadSeasonData(id) {
+      const seasonInfo = seasonsIndex.find(s => s.id == id);
+      if (!seasonInfo) return;
+      const res = await fetch(`seasons/${seasonInfo.file}`);
+      currentSeasonData = await res.json();
+      const divisionSelect = document.getElementById('lmDivision');
+      divisionSelect.innerHTML = '';
+      Object.keys(currentSeasonData.divisions).forEach(div => {
+        const opt = document.createElement('option');
+        opt.value = div;
+        opt.textContent = div;
+        divisionSelect.appendChild(opt);
+      });
+      divisionSelect.value = Object.keys(currentSeasonData.divisions)[0];
+      await renderDivision();
+    }
+
+    async function fetchTeams(season, division) {
+      const q = query(
+        collection(db, 'teams'),
+        where('season', '==', season),
+        where('division', '==', division),
+        where('approved', '==', true)
+      );
+      const snap = await getDocs(q);
+      return snap.docs.map(d => d.data());
+    }
+
+    async function renderDivision() {
+      const divKey = document.getElementById('lmDivision').value;
+      const divData = currentSeasonData.divisions[divKey];
+      const teams = await fetchTeams(currentSeasonData.season, divKey);
+      if (teams.length) {
+        const standings = teams.map(t => ({ team: t.teamName, wins: 0, losses: 0 }));
+        renderStandings(standings);
+      } else {
+        renderStandings(divData.standings);
+      }
+      renderSchedule(divData.schedule);
+    }
+
+    function renderStandings(rows) {
+      const table = document.getElementById('standingsTable');
+      table.innerHTML = '';
+      const header = document.createElement('tr');
+      header.innerHTML = '<th class="px-2">Team</th><th class="px-2">W</th><th class="px-2">L</th>';
+      table.appendChild(header);
+      rows.forEach(r => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td class="px-2">${r.team}</td><td class="px-2">${r.wins}</td><td class="px-2">${r.losses}</td>`;
+        table.appendChild(tr);
+      });
+    }
+
+    function renderSchedule(weeks) {
+      const container = document.getElementById('scheduleContainer');
+      container.innerHTML = '';
+      weeks.forEach(w => {
+        const div = document.createElement('div');
+        div.className = 'mb-4';
+        const title = document.createElement('h3');
+        title.className = 'font-semibold mb-1';
+        title.textContent = `Week ${w.week}`;
+        div.appendChild(title);
+        const ul = document.createElement('ul');
+        w.matches.forEach(m => {
+          const li = document.createElement('li');
+          li.textContent = `${m.date}: ${m.away} @ ${m.home}`;
+          ul.appendChild(li);
+        });
+        div.appendChild(ul);
+        container.appendChild(div);
+      });
+    }
+
+    document.getElementById('lmSeason').addEventListener('change', e => loadSeasonData(e.target.value));
+    document.getElementById('lmDivision').addEventListener('change', renderDivision);
+
+    loadSeasons();
+  </script>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains a collection of static HTML pages for the community aro
 - **TeamSignUp.html** – Register new teams and edit their rosters using Firebase.
 - **Streamers.html** – Public directory of approved streamers loaded from Firestore.
 - **StreamersSubmit.html** – Form for anyone to submit a streamer for admin approval.
-- **StreamersAdmin.html** – Protected panel for approving or removing streamer entries.
+- **LeagueAdmin.html** – Protected panel for approving or removing streamer and team entries.
 - **TeamBuilder.html** – Simple form for creating your own team with a logo and banner stored in your browser.
 - **MontageBay.html** – Submit montage video links and view them all in one place.
 - **Team*.html** – Individual team pages with logos, rosters, streams, and contact links. Teams include Avalanche, ePidemic, DPRK, Zen, TXM, Flag Pole Smokers, Flying Tractors, Hegemony of Euros, KTL, Magic, null, DeadStop, Toxic Aimers, and Unhandled Exception.
@@ -33,7 +33,7 @@ You can open these pages directly:
 - [Team Sign-Up](TeamSignUp.html)
 - [Streamers](Streamers.html)
 - [Submit a Streamer](StreamersSubmit.html)
-- [Streamers Admin](StreamersAdmin.html)
+- [League Admin](LeagueAdmin.html)
 
 
 ## Usage

--- a/TeamSignUp.html
+++ b/TeamSignUp.html
@@ -37,6 +37,16 @@
           class="w-full px-3 py-2 rounded-md bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500" />
       </div>
 
+      <div>
+        <label class="block text-sm mb-1">Season</label>
+        <select id="seasonSelect" required class="w-full px-3 py-2 rounded-md bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"></select>
+      </div>
+
+      <div>
+        <label class="block text-sm mb-1">Division</label>
+        <select id="divisionSelect" required class="w-full px-3 py-2 rounded-md bg-gray-700 border border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"></select>
+      </div>
+
       <div id="playersContainer" class="space-y-2"></div>
       <button type="button" id="addPlayerBtn"
         class="w-full py-1 rounded-md bg-gray-700 hover:bg-gray-600">Add Player</button>
@@ -78,7 +88,10 @@
     const output = document.getElementById("teamOutput");
     const playersContainer = document.getElementById("playersContainer");
     const addPlayerBtn = document.getElementById("addPlayerBtn");
+    const seasonSelect = document.getElementById('seasonSelect');
+    const divisionSelect = document.getElementById('divisionSelect');
     let playerCount = 0;
+    let seasonsIndex = [];
 
     function addPlayerRow(name = "", twitch = "") {
       if (playerCount >= 7) return;
@@ -95,6 +108,38 @@
     addPlayerBtn.addEventListener("click", () => addPlayerRow());
     document.addEventListener("DOMContentLoaded", () => addPlayerRow());
 
+    async function loadSeasons() {
+      const res = await fetch('seasons/index.json');
+      seasonsIndex = await res.json();
+      seasonSelect.innerHTML = '';
+      seasonsIndex.forEach(season => {
+        const opt = document.createElement('option');
+        opt.value = season.id;
+        opt.textContent = `Season ${season.id}`;
+        seasonSelect.appendChild(opt);
+      });
+      const active = seasonsIndex.filter(s => s.active).pop() || seasonsIndex[seasonsIndex.length - 1];
+      seasonSelect.value = active.id;
+      await loadDivisions(active.id);
+    }
+
+    async function loadDivisions(id) {
+      const info = seasonsIndex.find(s => s.id == id);
+      if (!info) return;
+      const res = await fetch(`seasons/${info.file}`);
+      const data = await res.json();
+      divisionSelect.innerHTML = '';
+      Object.keys(data.divisions).forEach(div => {
+        const opt = document.createElement('option');
+        opt.value = div;
+        opt.textContent = div;
+        divisionSelect.appendChild(opt);
+      });
+    }
+
+    seasonSelect.addEventListener('change', e => loadDivisions(e.target.value));
+    loadSeasons();
+
     async function loadTeams() {
       output.innerHTML = "";
       const snapshot = await getDocs(collection(db, "teams"));
@@ -104,7 +149,7 @@
         li.className = "bg-gray-700 p-2 rounded-md";
         const players = (data.players || []).map(p => p.name).join(', ');
         const bench = (data.benchPlayers || []).join(', ');
-        li.innerHTML = `<strong>${data.teamName} [${data.teamTag}]</strong><br>Players: ${players}${bench ? `<br>Bench: ${bench}` : ''}`;
+        li.innerHTML = `<strong>${data.teamName} [${data.teamTag}]</strong> - Season ${data.season} ${data.division}<br>Players: ${players}${bench ? `<br>Bench: ${bench}` : ''}`;
         output.appendChild(li);
       });
     }
@@ -113,6 +158,8 @@
       e.preventDefault();
       const teamName = document.getElementById("teamName").value.trim();
       const teamTag = document.getElementById("teamTag").value.trim();
+      const season = parseInt(seasonSelect.value, 10);
+      const division = divisionSelect.value;
       const benchPlayers = document.getElementById("benchPlayers").value.trim().split(',').map(p => p.trim()).filter(Boolean);
       const players = Array.from(playersContainer.querySelectorAll('.player-row')).map(row => {
         const inputs = row.querySelectorAll('input');
@@ -121,12 +168,13 @@
         if (!name) return null;
         return { name, twitch };
       }).filter(Boolean);
-      if (!teamName || !teamTag || players.length === 0) return;
-      await addDoc(collection(db, "teams"), { teamName, teamTag, players, benchPlayers });
+      if (!teamName || !teamTag || players.length === 0 || !division || isNaN(season)) return;
+      await addDoc(collection(db, "teams"), { teamName, teamTag, season, division, players, benchPlayers, approved: false });
       form.reset();
       playersContainer.innerHTML = '';
       playerCount = 0;
       addPlayerRow();
+      loadDivisions(seasonSelect.value);
       loadTeams();
     });
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,5 +11,17 @@ service cloud.firestore {
         && (!('avatarUrl' in request.resource.data) || request.resource.data.avatarUrl is string);
       allow update, delete: if request.auth != null;
     }
+
+    match /teams/{teamId} {
+      allow read: if resource.data.approved == true || request.auth != null;
+      allow create: if
+        request.resource.data.approved == false &&
+        request.resource.data.teamName is string &&
+        request.resource.data.teamTag is string &&
+        request.resource.data.season is int &&
+        request.resource.data.division is string &&
+        request.resource.data.division in ['TPL-O', 'TPL-IM', 'TPL-I'];
+      allow update, delete: if request.auth != null;
+    }
   }
 }

--- a/nav.html
+++ b/nav.html
@@ -10,9 +10,10 @@
             <li><a href="UpcomingEvents.html" class="hover:text-blue-400 transition">Upcoming Events</a></li>
             <!-- Replaced old Draft Sign-Up link with Team SignUp page -->
             <li><a href="TeamSignUp.html" class="hover:text-blue-400 transition">Team SignUp</a></li>
+            <li><a href="LeagueManager.html" class="hover:text-blue-400 transition">League Manager</a></li>
             <li><a href="Streamers.html" class="hover:text-blue-400 transition">Streamers</a></li>
             <li><a href="StreamersSubmit.html" class="hover:text-blue-400 transition">Submit Streamer</a></li>
-            <li><a href="StreamersAdmin.html" class="hover:text-blue-400 transition">Streamers Admin</a></li>
+            <li><a href="LeagueAdmin.html" class="hover:text-blue-400 transition">League Admin</a></li>
 
 
             <!-- <li><a href="TeamBuilder.html" class="hover:text-blue-400 transition">Create Team</a></li> -->

--- a/seasons/index.json
+++ b/seasons/index.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "file": "season1.json", "active": false },
+  { "id": 2, "file": "season2.json", "active": true }
+]

--- a/seasons/season1.json
+++ b/seasons/season1.json
@@ -1,0 +1,29 @@
+{
+  "season": 1,
+  "divisions": {
+    "TPL-O": {
+      "standings": [
+        { "team": "Team Alpha", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Alpha", "away": "Team Beta", "date": "2025-09-01" } ] }
+      ]
+    },
+    "TPL-IM": {
+      "standings": [
+        { "team": "Team Beta", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Gamma", "away": "Team Delta", "date": "2025-09-02" } ] }
+      ]
+    },
+    "TPL-I": {
+      "standings": [
+        { "team": "Team Gamma", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Epsilon", "away": "Team Zeta", "date": "2025-09-03" } ] }
+      ]
+    }
+  }
+}

--- a/seasons/season2.json
+++ b/seasons/season2.json
@@ -1,0 +1,29 @@
+{
+  "season": 2,
+  "divisions": {
+    "TPL-O": {
+      "standings": [
+        { "team": "Team Omega", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Omega", "away": "Team Sigma", "date": "2026-09-01" } ] }
+      ]
+    },
+    "TPL-IM": {
+      "standings": [
+        { "team": "Team Sigma", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Tau", "away": "Team Upsilon", "date": "2026-09-02" } ] }
+      ]
+    },
+    "TPL-I": {
+      "standings": [
+        { "team": "Team Tau", "wins": 0, "losses": 0 }
+      ],
+      "schedule": [
+        { "week": 1, "matches": [ { "home": "Team Phi", "away": "Team Chi", "date": "2026-09-03" } ] }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce JSON season definitions with TPL-O, TPL-IM and TPL-I divisions
- add LeagueManager page to browse seasons, standings and schedules
- extend team signup and Firestore rules to capture season/division info and require approval
- manage team approvals and edits within the League Admin page
- link League Manager in navigation
- fetch approved teams for each season/division into League Manager standings
- rename Streamers admin to League Admin and update links and headings

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894ce7eb3ec832a8f7a2736c7b57ef6