### PR TITLE
Rename Streamers Admin page to League Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains a collection of static HTML pages for the community aro
 - **TeamSignUp.html** – Register new teams and edit their rosters using Firebase.
 - **Streamers.html** – Public directory of approved streamers loaded from Firestore.
 - **StreamersSubmit.html** – Form for anyone to submit a streamer for admin approval.
-- **StreamersAdmin.html** – Protected panel for approving or removing streamer entries.
+- **StreamersAdmin.html** – League Admin panel for approving or removing streamer entries.
 - **TeamBuilder.html** – Simple form for creating your own team with a logo and banner stored in your browser.
 - **MontageBay.html** – Submit montage video links and view them all in one place.
 - **Team*.html** – Individual team pages with logos, rosters, streams, and contact links. Teams include Avalanche, ePidemic, DPRK, Zen, TXM, Flag Pole Smokers, Flying Tractors, Hegemony of Euros, KTL, Magic, null, DeadStop, Toxic Aimers, and Unhandled Exception.
@@ -33,7 +33,7 @@ You can open these pages directly:
 - [Team Sign-Up](TeamSignUp.html)
 - [Streamers](Streamers.html)
 - [Submit a Streamer](StreamersSubmit.html)
-- [Streamers Admin](StreamersAdmin.html)
+- [League Admin](StreamersAdmin.html)
 
 
 ## Usage

--- a/StreamersAdmin.html
+++ b/StreamersAdmin.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Streamer Admin</title>
+  <title>League Admin</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script src="oauth.js"></script>
 </head>

--- a/nav.html
+++ b/nav.html
@@ -13,7 +13,7 @@
             <li><a href="LeagueManager.html" class="hover:text-blue-400 transition">League Manager</a></li>
             <li><a href="Streamers.html" class="hover:text-blue-400 transition">Streamers</a></li>
             <li><a href="StreamersSubmit.html" class="hover:text-blue-400 transition">Submit Streamer</a></li>
-            <li><a href="StreamersAdmin.html" class="hover:text-blue-400 transition">Streamers Admin</a></li>
+            <li><a href="StreamersAdmin.html" class="hover:text-blue-400 transition">League Admin</a></li>
 
 
             <!-- <li><a href="TeamBuilder.html" class="hover:text-blue-400 transition">Create Team</a></li> -->


### PR DESCRIPTION
## Summary
- Retitle StreamersAdmin page to **League Admin** in document title and navigation menu
- Update documentation to reference the new League Admin page name

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f1e0cbe4832abd6408ea50a8688b