### PR TITLE
Rename League Manager page to TPL Standings and Matches

### DIFF
--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>League Manager</title>
+  <title>TPL Standings and Matches</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script src="oauth.js"></script>
 </head>
@@ -19,7 +19,7 @@
   </script>
 
   <div class="w-full max-w-4xl p-4">
-    <h1 class="text-2xl font-bold text-center mb-4">League Manager</h1>
+    <h1 class="text-2xl font-bold text-center mb-4">TPL Standings and Matches</h1>
     <div class="flex flex-col md:flex-row gap-4 justify-center mb-6">
       <div>
         <label class="block text-sm mb-1">Season</label>

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ This repository contains a collection of static HTML pages for the community aro
 - **TwinsTournamentDataCenter.html** – Score-per-minute chart and documents for the tournament.
 - **UpcomingEvents.html** – Schedule of upcoming events with the Twins image.
 - **TeamSignUp.html** – Register new teams and edit their rosters using Firebase.
+- **LeagueManager.html** – TPL Standings and Matches for each season and division.
 - **Streamers.html** – Public directory of approved streamers loaded from Firestore.
 - **StreamersSubmit.html** – Form for anyone to submit a streamer for admin approval.
-- **StreamersAdmin.html** – Protected panel for approving or removing streamer entries.
+- **StreamersAdmin.html** – League Admin panel for approving or removing streamer entries.
 - **TeamBuilder.html** – Simple form for creating your own team with a logo and banner stored in your browser.
 - **MontageBay.html** – Submit montage video links and view them all in one place.
 - **Team*.html** – Individual team pages with logos, rosters, streams, and contact links. Teams include Avalanche, ePidemic, DPRK, Zen, TXM, Flag Pole Smokers, Flying Tractors, Hegemony of Euros, KTL, Magic, null, DeadStop, Toxic Aimers, and Unhandled Exception.
@@ -31,9 +32,10 @@ You can open these pages directly:
 - [Twins Tournament Data Center](TwinsTournamentDataCenter.html)
 - [Upcoming Events](UpcomingEvents.html)
 - [Team Sign-Up](TeamSignUp.html)
+- [TPL Standings and Matches](LeagueManager.html)
 - [Streamers](Streamers.html)
 - [Submit a Streamer](StreamersSubmit.html)
-- [Streamers Admin](StreamersAdmin.html)
+- [League Admin](StreamersAdmin.html)
 
 
 ## Usage

--- a/StreamersAdmin.html
+++ b/StreamersAdmin.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Streamer Admin</title>
+  <title>League Admin</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script src="oauth.js"></script>
 </head>

--- a/nav.html
+++ b/nav.html
@@ -10,10 +10,10 @@
             <li><a href="UpcomingEvents.html" class="hover:text-blue-400 transition">Upcoming Events</a></li>
             <!-- Replaced old Draft Sign-Up link with Team SignUp page -->
             <li><a href="TeamSignUp.html" class="hover:text-blue-400 transition">Team SignUp</a></li>
-            <li><a href="LeagueManager.html" class="hover:text-blue-400 transition">League Manager</a></li>
+             <li><a href="LeagueManager.html" class="hover:text-blue-400 transition">TPL Standings and Matches</a></li>
             <li><a href="Streamers.html" class="hover:text-blue-400 transition">Streamers</a></li>
             <li><a href="StreamersSubmit.html" class="hover:text-blue-400 transition">Submit Streamer</a></li>
-            <li><a href="StreamersAdmin.html" class="hover:text-blue-400 transition">Streamers Admin</a></li>
+            <li><a href="StreamersAdmin.html" class="hover:text-blue-400 transition">League Admin</a></li>
 
 
             <!-- <li><a href="TeamBuilder.html" class="hover:text-blue-400 transition">Create Team</a></li> -->


### PR DESCRIPTION
## Summary
- Retitle LeagueManager page to **TPL Standings and Matches** in the document title and heading
- Update navigation to show **TPL Standings and Matches** and document the page in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f1e0cbe4832abd6408ea50a8688b