### PR TITLE
Load shared navigation with include.js

### DIFF
--- a/DraftSignUp.html
+++ b/DraftSignUp.html
@@ -73,18 +73,7 @@
   </style>
 </head>
 <body class="text-white">
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch('nav.html').then(r => r.text()).then(html => {
-      document.getElementById('nav-placeholder').innerHTML = html;
-      if (window.twitchOAuth) {
-        twitchOAuth.updateNav();
-        twitchOAuth.initLiveTeamsMenu();
-        const panel = document.getElementById('live-teams-panel');
-        if (panel) panel.style.top = '9rem';
-      }
-    });
-  </script>
+    <div data-include="nav.html"></div>
   <div id="root"></div>
   <script type="text/babel">
     const POSITIONS = ['HoF', 'LD', 'MD', 'MO', 'HO', 'LO', 'Capper'];
@@ -433,5 +422,6 @@
     const root = ReactDOM.createRoot(document.getElementById('root'));
     root.render(<App />);
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -7,16 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch('nav.html').then(r => r.text()).then(html => {
-      document.getElementById('nav-placeholder').innerHTML = html;
-      if (window.twitchOAuth) {
-        twitchOAuth.updateNav();
-        twitchOAuth.initLiveTeamsMenu();
-      }
-    });
-  </script>
+    <div data-include="nav.html"></div>
 
   <div class="w-full max-w-4xl p-4">
     <h1 class="text-2xl font-bold text-center mb-4">TPL Standings and Matches</h1>
@@ -159,5 +150,6 @@
 
     loadSeasons();
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/MontageBay.html
+++ b/MontageBay.html
@@ -8,16 +8,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch('nav.html').then(r=>r.text()).then(html=>{
-      document.getElementById('nav-placeholder').innerHTML = html;
-      if (window.twitchOAuth) {
-        twitchOAuth.updateNav();
-        twitchOAuth.initLiveTeamsMenu();
-      }
-    });
-  </script>
+    <div data-include="nav.html"></div>
 
   <main class="container mx-auto p-4">
     <h1 class="text-3xl font-bold mb-4 text-center">Montage Bay</h1>
@@ -74,5 +65,6 @@
 
   document.addEventListener('DOMContentLoaded', loadMontages);
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/Streamers.html
+++ b/Streamers.html
@@ -7,18 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch('nav.html').then(r => r.text()).then(html => {
-      document.getElementById('nav-placeholder').innerHTML = html;
-      if (window.twitchOAuth) {
-        twitchOAuth.updateNav();
-        twitchOAuth.initLiveTeamsMenu();
-        const panel = document.getElementById('live-teams-panel');
-        if (panel) panel.style.top = '9rem';
-      }
-    });
-  </script>
+    <div data-include="nav.html"></div>
 
   <div class="container mx-auto px-4 mt-8">
     <h1 class="text-3xl font-bold text-center mb-6">Tribes Streamers</h1>
@@ -82,5 +71,6 @@
     loadStreamers().catch(() => document.getElementById('noStreamers').classList.remove('hidden'));
 
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/StreamersAdmin.html
+++ b/StreamersAdmin.html
@@ -7,18 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch('nav.html').then(r => r.text()).then(html => {
-      document.getElementById('nav-placeholder').innerHTML = html;
-      if (window.twitchOAuth) {
-        twitchOAuth.updateNav();
-        twitchOAuth.initLiveTeamsMenu();
-        const panel = document.getElementById('live-teams-panel');
-        if (panel) panel.style.top = '9rem';
-      }
-    });
-  </script>
+    <div data-include="nav.html"></div>
 
   <div id="loginDiv" class="max-w-sm mx-auto mt-10 space-y-4">
     <h1 class="text-2xl font-bold text-center">Admin Login</h1>
@@ -205,5 +194,6 @@
       }));
     }
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/StreamersSubmit.html
+++ b/StreamersSubmit.html
@@ -7,18 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch('nav.html').then(r => r.text()).then(html => {
-      document.getElementById('nav-placeholder').innerHTML = html;
-      if (window.twitchOAuth) {
-        twitchOAuth.updateNav();
-        twitchOAuth.initLiveTeamsMenu();
-        const panel = document.getElementById('live-teams-panel');
-        if (panel) panel.style.top = '9rem';
-      }
-    });
-  </script>
+    <div data-include="nav.html"></div>
 
   <div class="max-w-md mx-auto mt-10 p-6 bg-gray-800 rounded-lg shadow">
     <h1 class="text-2xl font-bold text-center mb-4">Submit a Streamer</h1>
@@ -73,5 +62,6 @@
       document.getElementById('status').classList.remove('hidden');
     });
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TPLTeamsDashboard.html
+++ b/TPLTeamsDashboard.html
@@ -61,20 +61,7 @@
     </style>
 </head>
 <body class="bg-gray-900 text-white font-sans">
-    <div id="nav-placeholder"></div>
-    <script>
-        fetch("nav.html")
-            .then(res => res.text())
-            .then(html => {
-                document.getElementById("nav-placeholder").innerHTML = html;
-                if (window.twitchOAuth) {
-                    twitchOAuth.updateNav();
-                    twitchOAuth.initLiveTeamsMenu();
-                    const panel = document.getElementById('live-teams-panel');
-                    if (panel) panel.style.top = '9rem';
-                }
-            });
-    </script>
+    <div data-include="nav.html"></div>
     <!-- Header -->
     <header class="bg-gray-800 py-6 shadow-lg">
         <div class="container mx-auto px-4 text-center">
@@ -548,5 +535,6 @@
             }
         });
     </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamAV.html
+++ b/TeamAV.html
@@ -86,6 +86,7 @@
     </style>
 </head>
 <body class="gradient-bg text-white font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="bg-gray-900 bg-opacity-90 p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -226,5 +227,6 @@
             <p>Follow us on <a href="wwww.team-avalanche.online" target="_blank" class="text-red-400 hover:text-red-300">@Avalanche</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamDPRK.html
+++ b/TeamDPRK.html
@@ -225,6 +225,7 @@
     </script>
 </head>
 <body>
+    <div data-include="nav.html"></div>
     <header>
         <img src="https://github.com/T24085/TeamDPRK/blob/main/TeamDPRKLogo3.png?raw=true" alt="DPRK Logo">
         <h1>[DPRK] TPL</h1>
@@ -419,5 +420,6 @@
         <p>© 2025 [DPRK] Tribes Professional League. All rights reserved.</p>
         <img src="https://github.com/T24085/TeamDPRK/blob/main/DPRKLOGO.png?raw=true" alt="DPRK Logo">
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamDS.html
+++ b/TeamDS.html
@@ -157,6 +157,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -322,5 +323,6 @@
             <p>Follow us on <a href="https://x.com/DS" target="_blank" class="text-gray-300 hover:text-gray-400">@DS</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamEPI.html
+++ b/TeamEPI.html
@@ -86,6 +86,7 @@
     </style>
 </head>
 <body class="gradient-bg text-white font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="bg-gray-900 bg-opacity-90 p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -201,5 +202,6 @@
             <p>Follow us on <a href="https://x.com/Epidemic" target="_blank" class="text-purple-300 hover:text-purple-200">@Epidemic</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamFPS.html
+++ b/TeamFPS.html
@@ -152,6 +152,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -303,5 +304,6 @@
             <p>Follow us on <a href="https://x.com/FPS" target="_blank" class="text-red-300 hover:text-red-200">@FPS</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamFT.html
+++ b/TeamFT.html
@@ -153,6 +153,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -307,5 +308,6 @@
             <p>Follow us on <a href="https://x.com/FlyingTractors" target="_blank" class="text-green-300 hover:text-green-200">@FlyingTractors</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamHoE.html
+++ b/TeamHoE.html
@@ -113,6 +113,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-serif">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -286,5 +287,6 @@
             <p>Follow us on <a href="https://x.com/HoE" target="_blank" class="text-yellow-400 hover:text-yellow-300">@HoE</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamKTL.html
+++ b/TeamKTL.html
@@ -152,6 +152,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -276,5 +277,6 @@
             <p>Follow us on <a href="https://x.com/KTL" target="_blank" class="text-cyan-300 hover:text-cyan-200">@KTL</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamMagic.html
+++ b/TeamMagic.html
@@ -153,6 +153,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-serif">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -305,5 +306,6 @@
             <p>Follow us on <a href="https://x.com/Magic" target="_blank" class="text-yellow-400 hover:text-yellow-300">@Magic</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamNull.html
+++ b/TeamNull.html
@@ -153,6 +153,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -278,5 +279,6 @@
             <p>Follow us on <a href="https://x.com/NULL" target="_blank" class="text-green-300 hover:text-green-200">@NULL</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamSignUp.html
+++ b/TeamSignUp.html
@@ -7,18 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch('nav.html').then(r => r.text()).then(html => {
-      document.getElementById('nav-placeholder').innerHTML = html;
-      if (window.twitchOAuth) {
-        twitchOAuth.updateNav();
-        twitchOAuth.initLiveTeamsMenu();
-        const panel = document.getElementById('live-teams-panel');
-        if (panel) panel.style.top = '9rem';
-      }
-    });
-  </script>
+    <div data-include="nav.html"></div>
 
 
   <div class="bg-gray-800 shadow-lg rounded-2xl p-8 w-full max-w-2xl mt-8">
@@ -204,5 +193,6 @@
     });
   </script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamTXM.html
+++ b/TeamTXM.html
@@ -91,6 +91,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -261,5 +262,6 @@
             <p>Follow us on <a href="https://x.com/TXM" target="_blank" class="text-blue-300 hover:text-blue-200">@TXM</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamToxicAimers.html
+++ b/TeamToxicAimers.html
@@ -153,6 +153,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -309,5 +310,6 @@
             <p>Follow us on <a href="https://x.com/ToxicAimers" target="_blank" class="text-green-300 hover:text-purple-400">@ToxicAimers</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamUE.html
+++ b/TeamUE.html
@@ -153,6 +153,7 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-mono">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -271,5 +272,6 @@
             <p>Follow us on <a href="https://x.com/UE" target="_blank" class="text-red-400 hover:text-red-300">@UE</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamZen.html
+++ b/TeamZen.html
@@ -103,6 +103,7 @@
     </style>
 </head>
 <body class="gradient-bg text-cream-100 font-sans">
+    <div data-include="nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -239,5 +240,6 @@
             <p>Follow us on <a href="https://x.com/ZEN" target="_blank" class="text-orange-300 hover:text-orange-200">@ZEN</a></p>
         </div>
     </footer>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TournamentBrackets.html
+++ b/TournamentBrackets.html
@@ -82,18 +82,7 @@
   </style>
 </head>
 <body class="text-white">
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch('nav.html').then(r => r.text()).then(html => {
-      document.getElementById('nav-placeholder').innerHTML = html;
-      if (window.twitchOAuth) {
-        twitchOAuth.updateNav();
-        twitchOAuth.initLiveTeamsMenu();
-        const panel = document.getElementById('live-teams-panel');
-        if (panel) panel.style.top = '9rem';
-      }
-    });
-  </script>
+    <div data-include="nav.html"></div>
   <div id="root"></div>
   <script type="text/babel">
     const Match = ({ match, roundIndex, matchIndex, onSubmitScores, tournamentStyle, matchHeight, positionTop, nextMatchPosition, prevMatchPositions }) => {
@@ -1657,5 +1646,6 @@
     const root = ReactDOM.createRoot(document.getElementById('root'));
     root.render(<App />);
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -32,18 +32,7 @@
   </style>
 </head>
 <body class="text-white">
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch("nav.html")
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById("nav-placeholder").innerHTML = html;
-          if (window.twitchOAuth) {
-            twitchOAuth.updateNav();
-            twitchOAuth.initLiveTeamsMenu();
-          }
-      });
-  </script>
+    <div data-include="nav.html"></div>
   <div id="root"></div>
   <script type="text/babel">
     const POSITIONS = ['HoF', 'LD', 'MD', 'MO', 'HO', 'LO', 'Capper'];
@@ -439,5 +428,6 @@
     const root = ReactDOM.createRoot(document.getElementById('root'));
     root.render(<App />);
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -116,18 +116,7 @@
     </style>
 </head>
 <body class="font-sans">
-    <div id="nav-placeholder"></div>
-    <script>
-        fetch("nav.html")
-            .then(res => res.text())
-            .then(html => {
-                document.getElementById("nav-placeholder").innerHTML = html;
-                if (window.twitchOAuth) {
-                    twitchOAuth.updateNav();
-                    twitchOAuth.initLiveTeamsMenu();
-                }
-            });
-    </script>
+    <div data-include="nav.html"></div>
     <header class="text-center py-6">
         <h1 class="text-4xl font-bold text-violet-400">Tribes Professional League Scrim Watcher</h1>
     </header>
@@ -409,5 +398,6 @@ function renderTeamCard(team, container){
         }
 
     </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TwinsTournamentDataCenter.html
+++ b/TwinsTournamentDataCenter.html
@@ -86,16 +86,7 @@
     </style>
 </head>
 <body class="text-white min-h-screen">
-    <div id="nav-placeholder"></div>
-    <script>
-        fetch('nav.html').then(r => r.text()).then(html => {
-            document.getElementById('nav-placeholder').innerHTML = html;
-            if (window.twitchOAuth) {
-                twitchOAuth.updateNav();
-                twitchOAuth.initLiveTeamsMenu();
-            }
-        });
-    </script>
+    <div data-include="nav.html"></div>
     <div id="root"></div>
 
     <script type="text/babel">
@@ -204,6 +195,7 @@
         const root = ReactDOM.createRoot(document.getElementById('root'));
         root.render(<Dashboard />);
     </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>
 

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -299,18 +299,7 @@
   </style>
 </head>
 <body>
-  <div id="nav-placeholder"></div>
-  <script>
-    fetch("nav.html")
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById("nav-placeholder").innerHTML = html;
-          if (window.twitchOAuth) {
-            twitchOAuth.updateNav();
-            twitchOAuth.initLiveTeamsMenu();
-          }
-      });
-  </script>
+    <div data-include="nav.html"></div>
   <div class="container">
     <header>
       <div class="form-section">
@@ -680,5 +669,6 @@
     if (liveBtn) liveBtn.textContent = showOnlyLive ? 'Show All Channels' : 'Show Only Live';
     updateLiveChannels();
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/TwitchFeedMobile.html
+++ b/TwitchFeedMobile.html
@@ -292,6 +292,7 @@
   </style>
 </head>
 <body>
+    <div data-include="nav.html"></div>
   <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
     <div class="container mx-auto">
       <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
@@ -615,5 +616,6 @@
     // Initial render
     renderStreams();
   </script>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/UpcomingEvents.html
+++ b/UpcomingEvents.html
@@ -8,20 +8,12 @@
     <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white">
-    <div id="nav-placeholder"></div>
-    <script>
-        fetch('nav.html').then(r => r.text()).then(html => {
-            document.getElementById('nav-placeholder').innerHTML = html;
-            if (window.twitchOAuth) {
-                twitchOAuth.updateNav();
-                twitchOAuth.initLiveTeamsMenu();
-            }
-        });
-    </script>
+    <div data-include="nav.html"></div>
     <main class="container mx-auto p-4">
         <h1 class="text-3xl font-bold mb-4 text-center">Upcoming Events</h1>
         <img src="Twin.jpg" alt="Twins" class="mx-auto mb-4 max-w-xs">
         <iframe class="w-full h-[75vh] bg-white" src="https://docs.google.com/document/d/1wkWiFoTMbQoMkguv-cMBVqpg3hZzY0RJrZ9egVOWoNo/preview"></iframe>
     </main>
+    <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/assets/include.js
+++ b/assets/include.js
@@ -2,8 +2,8 @@
  * include.js
  * Loads HTML snippets into elements marked with [data-include]
  * Example usage in your page:
- *   <div data-include="/nav.html"></div>
- *   <script src="/assets/include.js" defer></script>
+ *   <div data-include="nav.html"></div>
+ *   <script src="assets/include.js" defer></script>
  */
 (async () => {
   const targets = document.querySelectorAll('[data-include]');

--- a/nav.html
+++ b/nav.html
@@ -4,15 +4,15 @@
     <div class="flex h-16 items-center justify-between">
       <!-- Left: Brand -->
       <div class="flex items-center gap-3">
-        <a href="/index.html" class="flex items-center gap-2">
-          <img src="/assets/logo.svg" alt="TRL" class="h-8 w-8" onerror="this.style.display='none'">
+        <a href="index.html" class="flex items-center gap-2">
+          <img src="assets/logo.svg" alt="TRL" class="h-8 w-8" onerror="this.style.display='none'">
           <span class="text-white font-semibold tracking-wide">Tribes Rivals League</span>
         </a>
       </div>
 
       <!-- Desktop Nav -->
       <div class="hidden md:flex items-center gap-6">
-        <a href="/index.html" class="nav-link text-gray-200 hover:text-white">Home</a>
+        <a href="index.html" class="nav-link text-gray-200 hover:text-white">Home</a>
         <div class="relative group">
           <button class="text-gray-200 hover:text-white flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
             Teams
@@ -21,22 +21,33 @@
             </svg>
           </button>
           <div class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute mt-2 min-w-48 rounded-xl border border-gray-800 bg-gray-900 shadow-xl p-2">
-            <a href="/TPLTeamsDashboard.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
+            <a href="TPLTeamsDashboard.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
             <div class="my-2 h-px bg-gray-800"></div>
-            <a href="/TeamAV.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
-            <a href="/TeamFPS.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">FPS</a>
-            <a href="/TeamFT.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">FT</a>
+            <a href="TeamAV.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
+            <a href="TeamDPRK.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">DPRK</a>
+            <a href="TeamDS.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
+            <a href="TeamEPI.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
+            <a href="TeamFPS.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
+            <a href="TeamFT.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
+            <a href="TeamHoE.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
+            <a href="TeamKTL.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
+            <a href="TeamMagic.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
+            <a href="TeamNull.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">null [null]</a>
+            <a href="TeamTXM.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
+            <a href="TeamToxicAimers.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
+            <a href="TeamUE.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
+            <a href="TeamZen.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
           </div>
         </div>
-        <a href="/Schedule.html" class="nav-link text-gray-200 hover:text-white">Schedule</a>
-        <a href="/Standings.html" class="nav-link text-gray-200 hover:text-white">Standings</a>
-        <a href="/Streamers.html" class="nav-link text-gray-200 hover:text-white">Streams</a>
+        <a href="Schedule.html" class="nav-link text-gray-200 hover:text-white">Schedule</a>
+        <a href="Standings.html" class="nav-link text-gray-200 hover:text-white">Standings</a>
+        <a href="Streamers.html" class="nav-link text-gray-200 hover:text-white">Streams</a>
       </div>
 
       <!-- Right: CTA -->
       <div class="hidden md:flex items-center gap-3">
-        <a href="/DraftSignUp.html" class="px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium">Draft Sign-Up</a>
-        <a href="/LeagueManager.html" class="px-3 py-1.5 rounded-lg border border-gray-800 text-gray-200 hover:bg-gray-800 text-sm">Admin</a>
+        <a href="DraftSignUp.html" class="px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium">Draft Sign-Up</a>
+        <a href="LeagueManager.html" class="px-3 py-1.5 rounded-lg border border-gray-800 text-gray-200 hover:bg-gray-800 text-sm">Admin</a>
       </div>
 
       <!-- Mobile hamburger -->
@@ -54,7 +65,7 @@
   <!-- Mobile panel -->
   <div id="mobile-menu" class="md:hidden hidden border-t border-gray-800">
     <div class="space-y-1 px-4 py-3">
-      <a href="/index.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Home</a>
+      <a href="index.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Home</a>
       <details class="group">
         <summary class="flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">
           <span>Teams</span>
@@ -63,18 +74,29 @@
           </svg>
         </summary>
         <div class="mt-1 pl-3 space-y-1">
-          <a href="/TPLTeamsDashboard.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
-          <a href="/TeamAV.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
-          <a href="/TeamFPS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">FPS</a>
-          <a href="/TeamFT.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">FT</a>
+          <a href="TPLTeamsDashboard.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
+          <a href="TeamAV.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
+          <a href="TeamDPRK.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">DPRK</a>
+          <a href="TeamDS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
+          <a href="TeamEPI.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
+          <a href="TeamFPS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
+          <a href="TeamFT.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
+          <a href="TeamHoE.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
+          <a href="TeamKTL.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
+          <a href="TeamMagic.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
+          <a href="TeamNull.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">null [null]</a>
+          <a href="TeamTXM.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
+          <a href="TeamToxicAimers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
+          <a href="TeamUE.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
+          <a href="TeamZen.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
         </div>
       </details>
-      <a href="/Schedule.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Schedule</a>
-      <a href="/Standings.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Standings</a>
-      <a href="/Streamers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streams</a>
+      <a href="Schedule.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Schedule</a>
+      <a href="Standings.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Standings</a>
+      <a href="Streamers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streams</a>
       <div class="pt-2">
-        <a href="/DraftSignUp.html" class="block rounded-lg px-3 py-2 bg-indigo-600 hover:bg-indigo-500 text-white">Draft Sign-Up</a>
-        <a href="/LeagueManager.html" class="block rounded-lg mt-1 px-3 py-2 border border-gray-800 text-gray-200 hover:bg-gray-800">Admin</a>
+        <a href="DraftSignUp.html" class="block rounded-lg px-3 py-2 bg-indigo-600 hover:bg-indigo-500 text-white">Draft Sign-Up</a>
+        <a href="LeagueManager.html" class="block rounded-lg mt-1 px-3 py-2 border border-gray-800 text-gray-200 hover:bg-gray-800">Admin</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Switch include snippet and loader script to relative paths so `nav.html` loads correctly from any page
- Expand `nav.html` with links to all team pages and use relative URLs for internal navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896700b6e50832a94dce183b51f3141