### PR TITLE
Expand navigation with full team, stream, and league links

### DIFF
--- a/TPLTeamsDashboard.html
+++ b/TPLTeamsDashboard.html
@@ -61,7 +61,7 @@
     </style>
 </head>
 <body class="bg-gray-900 text-white font-sans">
-    <div data-include="/nav.html"></div>
+    <div id="nav-placeholder"></div>
     <!-- Header -->
     <header class="bg-gray-800 py-6 shadow-lg">
         <div class="container mx-auto px-4 text-center">
@@ -535,14 +535,31 @@
             }
         });
     </script>
-    <script src="/assets/include.js" defer></script>
     <script>
-        document.addEventListener('includes-loaded', () => {
-            if (window.twitchOAuth) {
-                twitchOAuth.updateNav();
-                twitchOAuth.initLiveTeamsMenu();
+        async function loadNav() {
+            const placeholder = document.getElementById('nav-placeholder');
+            try {
+                const res = await fetch('nav.html');
+                if (!res.ok) throw new Error(`Nav fetch failed: ${res.status}`);
+                const html = await res.text();
+                placeholder.innerHTML = html;
+                placeholder.querySelectorAll('script').forEach(oldScript => {
+                    const newScript = document.createElement('script');
+                    [...oldScript.attributes].forEach(attr =>
+                        newScript.setAttribute(attr.name, attr.value)
+                    );
+                    newScript.textContent = oldScript.textContent;
+                    oldScript.replaceWith(newScript);
+                });
+                if (window.twitchOAuth) {
+                    window.twitchOAuth.updateNav();
+                    window.twitchOAuth.initLiveTeamsMenu();
+                }
+            } catch (err) {
+                console.error('Failed to load navigation', err);
             }
-        });
+        }
+        loadNav();
     </script>
 </body>
 </html>

--- a/nav.html
+++ b/nav.html
@@ -4,15 +4,15 @@
     <div class="flex h-16 items-center justify-between">
       <!-- Left: Brand -->
       <div class="flex items-center gap-3">
-        <a href="/index.html" class="flex items-center gap-2">
-          <img src="/assets/logo.svg" alt="TRL" class="h-8 w-8" onerror="this.style.display='none'">
-          <span class="text-white font-semibold tracking-wide">Tribes Rivals League</span>
+        <a href="TPLTeamsDashboard.html" class="flex items-center gap-2">
+          <img src="assets/logo.svg" alt="TPL" class="h-8 w-8" onerror="this.style.display='none'">
+          <span class="text-white font-semibold tracking-wide">Tribes Professional League</span>
         </a>
       </div>
 
       <!-- Desktop Nav -->
       <div class="hidden md:flex items-center gap-6">
-        <a href="/index.html" class="nav-link text-gray-200 hover:text-white">Home</a>
+        <a href="TPLTeamsDashboard.html" class="nav-link text-gray-200 hover:text-white">Home</a>
         <div class="relative group">
           <button class="text-gray-200 hover:text-white flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
             Teams
@@ -21,22 +21,64 @@
             </svg>
           </button>
           <div class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute mt-2 min-w-48 rounded-xl border border-gray-800 bg-gray-900 shadow-xl p-2">
-            <a href="/TPLTeamsDashboard.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
+            <a href="TPLTeamsDashboard.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
             <div class="my-2 h-px bg-gray-800"></div>
-            <a href="/TeamAV.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
-            <a href="/TeamFPS.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">FPS</a>
-            <a href="/TeamFT.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">FT</a>
+            <a href="TeamAV.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
+            <a href="TeamDS.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
+            <a href="TeamDPRK.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">[DPRK] Team</a>
+            <a href="TeamEPI.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
+            <a href="TeamFPS.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
+            <a href="TeamFT.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
+            <a href="TeamHoE.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
+            <a href="TeamKTL.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
+            <a href="TeamMagic.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
+            <a href="TeamNull.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">null [null]</a>
+            <a href="TeamTXM.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
+            <a href="TeamToxicAimers.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
+            <a href="TeamUE.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
+            <a href="TeamZen.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
           </div>
         </div>
-        <a href="/Schedule.html" class="nav-link text-gray-200 hover:text-white">Schedule</a>
-        <a href="/Standings.html" class="nav-link text-gray-200 hover:text-white">Standings</a>
-        <a href="/Streamers.html" class="nav-link text-gray-200 hover:text-white">Streams</a>
+        <a href="Schedule.html" class="nav-link text-gray-200 hover:text-white">Schedule</a>
+        <a href="Standings.html" class="nav-link text-gray-200 hover:text-white">Standings</a>
+        <div class="relative group">
+          <button class="text-gray-200 hover:text-white flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            TPL League
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute mt-2 min-w-48 rounded-xl border border-gray-800 bg-gray-900 shadow-xl p-2">
+            <a href="TeamSignUp.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Team Sign Up</a>
+            <a href="LeagueManager.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">League Manager</a>
+            <a href="UpcomingEvents.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Upcoming Events</a>
+            <a href="TournamentManager.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Tournament Manager</a>
+          </div>
+        </div>
+        <div class="relative group">
+          <button class="text-gray-200 hover:text-white flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            Streams
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute mt-2 min-w-48 rounded-xl border border-gray-800 bg-gray-900 shadow-xl p-2">
+            <a href="Streamers.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Streamers</a>
+            <div class="my-2 h-px bg-gray-800"></div>
+            <a href="TwitchFeedDisplays.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Twitch Feed Displays</a>
+            <a href="TwitchFeedMobile.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Twitch Feed Mobile</a>
+            <a href="TribesScrimWatcher.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">TPL Scrim Watcher</a>
+            <div class="my-2 h-px bg-gray-800"></div>
+            <a href="StreamersAdmin.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Streamers Admin</a>
+            <a href="StreamersSubmit.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Streamers Submit</a>
+          </div>
+        </div>
       </div>
 
       <!-- Right: CTA -->
       <div class="hidden md:flex items-center gap-3">
-        <a href="/DraftSignUp.html" class="px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium">Draft Sign-Up</a>
-        <a href="/LeagueManager.html" class="px-3 py-1.5 rounded-lg border border-gray-800 text-gray-200 hover:bg-gray-800 text-sm">Admin</a>
+        <a href="DraftSignUp.html" class="px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium">Draft Sign-Up</a>
+        <a href="LeagueManager.html" class="px-3 py-1.5 rounded-lg border border-gray-800 text-gray-200 hover:bg-gray-800 text-sm">Admin</a>
       </div>
 
       <!-- Mobile hamburger -->
@@ -54,7 +96,7 @@
   <!-- Mobile panel -->
   <div id="mobile-menu" class="md:hidden hidden border-t border-gray-800">
     <div class="space-y-1 px-4 py-3">
-      <a href="/index.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Home</a>
+      <a href="TPLTeamsDashboard.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Home</a>
       <details class="group">
         <summary class="flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">
           <span>Teams</span>
@@ -63,25 +105,65 @@
           </svg>
         </summary>
         <div class="mt-1 pl-3 space-y-1">
-          <a href="/TPLTeamsDashboard.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
-          <a href="/TeamAV.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
-          <a href="/TeamFPS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">FPS</a>
-          <a href="/TeamFT.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">FT</a>
+          <a href="TPLTeamsDashboard.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
+          <a href="TeamAV.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
+          <a href="TeamDS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
+          <a href="TeamDPRK.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">[DPRK] Team</a>
+          <a href="TeamEPI.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
+          <a href="TeamFPS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
+          <a href="TeamFT.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
+          <a href="TeamHoE.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
+          <a href="TeamKTL.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
+          <a href="TeamMagic.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
+          <a href="TeamNull.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">null [null]</a>
+          <a href="TeamTXM.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
+          <a href="TeamToxicAimers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
+          <a href="TeamUE.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
+          <a href="TeamZen.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
         </div>
       </details>
-      <a href="/Schedule.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Schedule</a>
-      <a href="/Standings.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Standings</a>
-      <a href="/Streamers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streams</a>
+      <a href="Schedule.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Schedule</a>
+      <a href="Standings.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Standings</a>
+      <details class="group">
+        <summary class="flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">
+          <span>TPL League</span>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 group-open:rotate-180 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </summary>
+        <div class="mt-1 pl-3 space-y-1">
+          <a href="TeamSignUp.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Team Sign Up</a>
+          <a href="LeagueManager.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">League Manager</a>
+          <a href="UpcomingEvents.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Upcoming Events</a>
+          <a href="TournamentManager.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Tournament Manager</a>
+        </div>
+      </details>
+      <details class="group">
+        <summary class="flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">
+          <span>Streams</span>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 group-open:rotate-180 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </summary>
+        <div class="mt-1 pl-3 space-y-1">
+          <a href="Streamers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streamers</a>
+          <a href="TwitchFeedDisplays.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Twitch Feed Displays</a>
+          <a href="TwitchFeedMobile.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Twitch Feed Mobile</a>
+          <a href="TribesScrimWatcher.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">TPL Scrim Watcher</a>
+          <a href="StreamersAdmin.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streamers Admin</a>
+          <a href="StreamersSubmit.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streamers Submit</a>
+        </div>
+      </details>
       <div class="pt-2">
-        <a href="/DraftSignUp.html" class="block rounded-lg px-3 py-2 bg-indigo-600 hover:bg-indigo-500 text-white">Draft Sign-Up</a>
-        <a href="/LeagueManager.html" class="block rounded-lg mt-1 px-3 py-2 border border-gray-800 text-gray-200 hover:bg-gray-800">Admin</a>
+        <a href="DraftSignUp.html" class="block rounded-lg px-3 py-2 bg-indigo-600 hover:bg-indigo-500 text-white">Draft Sign-Up</a>
+        <a href="LeagueManager.html" class="block rounded-lg mt-1 px-3 py-2 border border-gray-800 text-gray-200 hover:bg-gray-800">Admin</a>
       </div>
     </div>
   </div>
 </nav>
 
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
+  function initNav() {
     // Mobile toggle
     const toggle = document.getElementById('nav-toggle');
     const menu = document.getElementById('mobile-menu');
@@ -94,14 +176,20 @@
     }
 
     // Highlight active link
-    const path = location.pathname.replace(/\\/index\\.html$/, '/');
+    const path = location.pathname.replace(/\/index\.html$/, '/');
     document.querySelectorAll('a.nav-link, #mobile-menu a').forEach(a => {
       try {
         const aPath = new URL(a.href, location.origin).pathname;
         if (aPath === location.pathname || (aPath.endsWith('/index.html') && path === '/')) {
-          a.classList.add('text-white','font-semibold');
+          a.classList.add('text-white', 'font-semibold');
         }
       } catch {}
     });
-  });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initNav);
+  } else {
+    initNav();
+  }
 </script>


### PR DESCRIPTION
## Summary
- Point brand and home links at the TPL dashboard
- List every team page under the Teams dropdown
- Add Streams dropdown linking to all streaming-related pages
- Introduce TPL League dropdown with Team Sign Up, League Manager, Upcoming Events, and Tournament Manager

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689768e928e8832a93f9d2941807b3c9