### PR TITLE
Add league manager interface and rename standings page

### DIFF
--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -2,16 +2,16 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>TPL Standings and Matches</title>
+  <title>TPL League Manager</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
-    <div data-include="/nav.html"></div>
+  <div data-include="/nav.html"></div>
 
-  <div class="w-full max-w-4xl p-4">
-    <h1 class="text-2xl font-bold text-center mb-4">TPL Standings and Matches</h1>
-    <div class="flex flex-col md:flex-row gap-4 justify-center mb-6">
+  <div class="w-full max-w-5xl p-4">
+    <h1 class="text-2xl font-bold text-center mb-4">League Manager</h1>
+    <div class="flex flex-col md:flex-row gap-4 mb-6">
       <div>
         <label class="block text-sm mb-1">Season</label>
         <select id="lmSeason" class="px-3 py-2 rounded-md bg-gray-700 border border-gray-600"></select>
@@ -20,136 +20,254 @@
         <label class="block text-sm mb-1">Division</label>
         <select id="lmDivision" class="px-3 py-2 rounded-md bg-gray-700 border border-gray-600"></select>
       </div>
+      <div>
+        <label class="block text-sm mb-1">Weeks</label>
+        <div class="flex gap-2">
+          <input id="weekCount" type="number" min="1" class="px-3 py-2 rounded-md bg-gray-700 border border-gray-600 w-20">
+          <button id="generateWeeks" class="px-3 py-2 bg-indigo-600 rounded-md text-white">Generate</button>
+        </div>
+      </div>
     </div>
 
-    <div>
+    <div id="weeksContainer" class="space-y-6"></div>
+
+    <button id="saveSchedule" class="mt-6 px-4 py-2 bg-green-600 rounded-md">Save Schedule</button>
+
+    <div id="standingsSection" class="mt-10">
       <h2 class="text-xl font-semibold mb-2">Standings</h2>
       <table id="standingsTable" class="min-w-full text-left"></table>
     </div>
-
-    <div class="mt-6">
-      <h2 class="text-xl font-semibold mb-2">Schedule</h2>
-      <div id="scheduleContainer"></div>
-    </div>
   </div>
 
-  <script type="module">
+<script type="module">
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+  import { getFirestore, doc, getDoc, setDoc, collection, getDocs, query, where } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
 
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
-    import { getFirestore, collection, getDocs, query, where } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+  const firebaseConfig = {
+    apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
+    authDomain: "team-sign-up-b5646.firebaseapp.com",
+    projectId: "team-sign-up-b5646",
+    storageBucket: "team-sign-up-b5646.firebasestorage.app",
+    messagingSenderId: "951471144681",
+    appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
+  };
 
-    const firebaseConfig = {
-      apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
-      authDomain: "team-sign-up-b5646.firebaseapp.com",
-      projectId: "team-sign-up-b5646",
-      storageBucket: "team-sign-up-b5646.firebasestorage.app",
-      messagingSenderId: "951471144681",
-      appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
-    };
+  const app = initializeApp(firebaseConfig);
+  const db = getFirestore(app);
 
-    const app = initializeApp(firebaseConfig);
-    const db = getFirestore(app);
+  let seasonsIndex = [];
+  let currentSeasonData = null;
+  let teams = [];
 
+  async function loadSeasons() {
+    const res = await fetch('seasons/index.json');
+    seasonsIndex = await res.json();
+    const seasonSelect = document.getElementById('lmSeason');
+    seasonsIndex.forEach(season => {
+      const opt = document.createElement('option');
+      opt.value = season.id;
+      opt.textContent = `Season ${season.id}`;
+      seasonSelect.appendChild(opt);
+    });
+    const active = seasonsIndex.filter(s => s.active).pop() || seasonsIndex[seasonsIndex.length - 1];
+    seasonSelect.value = active.id;
+    await loadSeasonData(active.id);
+  }
 
-    let seasonsIndex = [];
-    let currentSeasonData = null;
+  async function loadSeasonData(id) {
+    const seasonInfo = seasonsIndex.find(s => s.id == id);
+    if (!seasonInfo) return;
+    const res = await fetch(`seasons/${seasonInfo.file}`);
+    currentSeasonData = await res.json();
+    const divisionSelect = document.getElementById('lmDivision');
+    divisionSelect.innerHTML = '';
+    Object.keys(currentSeasonData.divisions).forEach(div => {
+      const opt = document.createElement('option');
+      opt.value = div;
+      opt.textContent = div;
+      divisionSelect.appendChild(opt);
+    });
+    divisionSelect.value = Object.keys(currentSeasonData.divisions)[0];
+    await loadTeams();
+    await loadSchedule();
+  }
 
-    async function loadSeasons() {
-      const res = await fetch('seasons/index.json');
-      seasonsIndex = await res.json();
-      const seasonSelect = document.getElementById('lmSeason');
-      seasonsIndex.forEach(season => {
-        const opt = document.createElement('option');
-        opt.value = season.id;
-        opt.textContent = `Season ${season.id}`;
-        seasonSelect.appendChild(opt);
-      });
-      const active = seasonsIndex.filter(s => s.active).pop() || seasonsIndex[seasonsIndex.length - 1];
-      seasonSelect.value = active.id;
-      await loadSeasonData(active.id);
+  async function loadTeams() {
+    const season = currentSeasonData.season;
+    const division = document.getElementById('lmDivision').value;
+    const q = query(
+      collection(db, 'teams'),
+      where('season', '==', season),
+      where('division', '==', division),
+      where('approved', '==', true)
+    );
+    const snap = await getDocs(q);
+    teams = snap.docs.map(d => d.data().teamName).sort();
+  }
+
+  function createTeamSelect(selected) {
+    const sel = document.createElement('select');
+    sel.className = 'px-2 py-1 rounded bg-gray-800 border border-gray-700';
+    teams.forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      opt.textContent = t;
+      if (t === selected) opt.selected = true;
+      sel.appendChild(opt);
+    });
+    return sel;
+  }
+
+  function createMatchRow(m = {}) {
+    const row = document.createElement('div');
+    row.className = 'flex flex-wrap items-center gap-2';
+    const date = document.createElement('input');
+    date.type = 'date';
+    date.value = m.date || '';
+    date.className = 'px-2 py-1 rounded bg-gray-800 border border-gray-700';
+    const away = createTeamSelect(m.away);
+    const at = document.createTextNode('@');
+    const home = createTeamSelect(m.home);
+    const awayScore = document.createElement('input');
+    awayScore.type = 'number';
+    awayScore.value = m.awayScore ?? '';
+    awayScore.className = 'w-16 px-2 py-1 rounded bg-gray-800 border border-gray-700';
+    const dash = document.createTextNode('-');
+    const homeScore = document.createElement('input');
+    homeScore.type = 'number';
+    homeScore.value = m.homeScore ?? '';
+    homeScore.className = 'w-16 px-2 py-1 rounded bg-gray-800 border border-gray-700';
+    const remove = document.createElement('button');
+    remove.textContent = 'X';
+    remove.className = 'px-2 py-1 bg-red-600 rounded';
+    remove.addEventListener('click', () => row.remove());
+    row.append(date, away, at, home, awayScore, dash, homeScore, remove);
+    return row;
+  }
+
+  function renderWeeks(weeks = []) {
+    const container = document.getElementById('weeksContainer');
+    container.innerHTML = '';
+    weeks.forEach(w => {
+      const div = document.createElement('div');
+      div.className = 'border border-gray-700 p-3 rounded-md';
+      div.dataset.week = w.week;
+      const header = document.createElement('div');
+      header.className = 'flex justify-between items-center mb-2';
+      const title = document.createElement('h3');
+      title.className = 'font-semibold';
+      title.textContent = `Week ${w.week}`;
+      const addBtn = document.createElement('button');
+      addBtn.textContent = 'Add Match';
+      addBtn.className = 'addMatch px-2 py-1 bg-gray-700 rounded';
+      header.append(title, addBtn);
+      div.appendChild(header);
+      const matchesContainer = document.createElement('div');
+      matchesContainer.className = 'space-y-2';
+      (w.matches || []).forEach(m => matchesContainer.appendChild(createMatchRow(m)));
+      div.appendChild(matchesContainer);
+      container.appendChild(div);
+    });
+  }
+
+  function gatherSchedule() {
+    return Array.from(document.querySelectorAll('#weeksContainer > div')).map(div => ({
+      week: Number(div.dataset.week),
+      matches: Array.from(div.querySelectorAll('.flex.flex-wrap')).map(row => {
+        const [date, awaySel, homeSel, awayScore, homeScore] = row.querySelectorAll('input, select');
+        return {
+          date: date.value,
+          away: awaySel.value,
+          home: homeSel.value,
+          awayScore: awayScore.value ? Number(awayScore.value) : null,
+          homeScore: homeScore.value ? Number(homeScore.value) : null
+        };
+      })
+    }));
+  }
+
+  function addWeek(num) {
+    const existing = gatherSchedule();
+    const start = existing.length + 1;
+    for (let i = 0; i < num; i++) {
+      existing.push({ week: start + i, matches: [] });
     }
+    renderWeeks(existing);
+  }
 
-    async function loadSeasonData(id) {
-      const seasonInfo = seasonsIndex.find(s => s.id == id);
-      if (!seasonInfo) return;
-      const res = await fetch(`seasons/${seasonInfo.file}`);
-      currentSeasonData = await res.json();
-      const divisionSelect = document.getElementById('lmDivision');
-      divisionSelect.innerHTML = '';
-      Object.keys(currentSeasonData.divisions).forEach(div => {
-        const opt = document.createElement('option');
-        opt.value = div;
-        opt.textContent = div;
-        divisionSelect.appendChild(opt);
-      });
-      divisionSelect.value = Object.keys(currentSeasonData.divisions)[0];
-
-      await renderDivision();
-    }
-
-    async function fetchTeams(season, division) {
-      const q = query(
-        collection(db, 'teams'),
-        where('season', '==', season),
-        where('division', '==', division),
-        where('approved', '==', true)
-      );
-      const snap = await getDocs(q);
-      return snap.docs.map(d => d.data());
-    }
-
-    async function renderDivision() {
-      const divKey = document.getElementById('lmDivision').value;
-      const divData = currentSeasonData.divisions[divKey];
-      const teams = await fetchTeams(currentSeasonData.season, divKey);
-      if (teams.length) {
-        const standings = teams.map(t => ({ team: t.teamName, wins: 0, losses: 0 }));
-        renderStandings(standings);
-      } else {
-        renderStandings(divData.standings);
+  function computeStandings(schedule) {
+    const table = {};
+    teams.forEach(t => (table[t] = { team: t, wins: 0, losses: 0 }));
+    schedule.forEach(w => w.matches.forEach(m => {
+      if (m.homeScore != null && m.awayScore != null) {
+        if (m.homeScore > m.awayScore) {
+          table[m.home].wins++;
+          table[m.away].losses++;
+        } else if (m.awayScore > m.homeScore) {
+          table[m.away].wins++;
+          table[m.home].losses++;
+        }
       }
-      renderSchedule(divData.schedule);
+    }));
+    return Object.values(table);
+  }
+
+  function renderStandings(rows) {
+    const tableEl = document.getElementById('standingsTable');
+    tableEl.innerHTML = '';
+    const header = document.createElement('tr');
+    header.innerHTML = '<th class="px-2">Team</th><th class="px-2">W</th><th class="px-2">L</th>';
+    tableEl.appendChild(header);
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td class="px-2">${r.team}</td><td class="px-2">${r.wins}</td><td class="px-2">${r.losses}</td>`;
+      tableEl.appendChild(tr);
+    });
+  }
+
+  async function loadSchedule() {
+    const season = currentSeasonData.season;
+    const division = document.getElementById('lmDivision').value;
+    const docRef = doc(db, 'leagueSchedules', `${season}-${division}`);
+    const snap = await getDoc(docRef);
+    let weeks = [];
+    if (snap.exists()) {
+      weeks = snap.data().weeks || [];
     }
+    renderWeeks(weeks);
+    renderStandings(computeStandings(weeks));
+  }
 
-    function renderStandings(rows) {
-      const table = document.getElementById('standingsTable');
-      table.innerHTML = '';
-      const header = document.createElement('tr');
-      header.innerHTML = '<th class="px-2">Team</th><th class="px-2">W</th><th class="px-2">L</th>';
-      table.appendChild(header);
-      rows.forEach(r => {
-        const tr = document.createElement('tr');
-        tr.innerHTML = `<td class="px-2">${r.team}</td><td class="px-2">${r.wins}</td><td class="px-2">${r.losses}</td>`;
-        table.appendChild(tr);
-      });
+  document.getElementById('generateWeeks').addEventListener('click', () => {
+    const num = parseInt(document.getElementById('weekCount').value);
+    if (num > 0) addWeek(num);
+  });
+
+  document.getElementById('weeksContainer').addEventListener('click', e => {
+    if (e.target.classList.contains('addMatch')) {
+      const container = e.target.closest('div[data-week]').querySelector('.space-y-2');
+      container.appendChild(createMatchRow());
     }
+  });
 
-    function renderSchedule(weeks) {
-      const container = document.getElementById('scheduleContainer');
-      container.innerHTML = '';
-      weeks.forEach(w => {
-        const div = document.createElement('div');
-        div.className = 'mb-4';
-        const title = document.createElement('h3');
-        title.className = 'font-semibold mb-1';
-        title.textContent = `Week ${w.week}`;
-        div.appendChild(title);
-        const ul = document.createElement('ul');
-        w.matches.forEach(m => {
-          const li = document.createElement('li');
-          li.textContent = `${m.date}: ${m.away} @ ${m.home}`;
-          ul.appendChild(li);
-        });
-        div.appendChild(ul);
-        container.appendChild(div);
-      });
-    }
+  document.getElementById('lmSeason').addEventListener('change', e => loadSeasonData(e.target.value));
 
-    document.getElementById('lmSeason').addEventListener('change', e => loadSeasonData(e.target.value));
-    document.getElementById('lmDivision').addEventListener('change', renderDivision);
+  document.getElementById('lmDivision').addEventListener('change', async () => {
+    await loadTeams();
+    await loadSchedule();
+  });
 
-    loadSeasons();
-  </script>
-    <script src="/assets/include.js" defer></script>
+  document.getElementById('saveSchedule').addEventListener('click', async () => {
+    const schedule = gatherSchedule();
+    const season = currentSeasonData.season;
+    const division = document.getElementById('lmDivision').value;
+    const docRef = doc(db, 'leagueSchedules', `${season}-${division}`);
+    await setDoc(docRef, { season, division, weeks: schedule });
+    renderStandings(computeStandings(schedule));
+  });
+
+  loadSeasons();
+</script>
+  <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repository contains a collection of static HTML pages for the community aro
 - **TwinsTournamentDataCenter.html** – Score-per-minute chart and documents for the tournament.
 - **UpcomingEvents.html** – Schedule of upcoming events with the Twins image.
 - **TeamSignUp.html** – Register new teams and edit their rosters using Firebase.
-- **LeagueManager.html** – TPL Standings and Matches for each season and division.
+- **StandingsAndMatches.html** – TPL Standings and Matches for each season and division.
+- **LeagueManager.html** – Admin panel for creating schedules and recording match results.
 - **Streamers.html** – Public directory of approved streamers loaded from Firestore.
 - **StreamersSubmit.html** – Form for anyone to submit a streamer for admin approval.
 - **StreamersAdmin.html** – League Admin panel for approving or removing streamer entries.
@@ -32,7 +33,8 @@ You can open these pages directly:
 - [Twins Tournament Data Center](TwinsTournamentDataCenter.html)
 - [Upcoming Events](UpcomingEvents.html)
 - [Team Sign-Up](TeamSignUp.html)
-- [TPL Standings and Matches](LeagueManager.html)
+- [TPL Standings and Matches](StandingsAndMatches.html)
+- [League Manager](LeagueManager.html)
 - [Streamers](Streamers.html)
 - [Submit a Streamer](StreamersSubmit.html)
 - [League Admin](StreamersAdmin.html)

--- a/Schedule.html
+++ b/Schedule.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=StandingsAndMatches.html">
+  <title>Schedule</title>
+</head>
+<body class="bg-gray-900 text-white">
+  <p class="p-4">Redirecting to <a href="StandingsAndMatches.html">Standings and Matches</a>...</p>
+</body>
+</html>

--- a/Standings.html
+++ b/Standings.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=StandingsAndMatches.html">
+  <title>Standings</title>
+</head>
+<body class="bg-gray-900 text-white">
+  <p class="p-4">Redirecting to <a href="StandingsAndMatches.html">Standings and Matches</a>...</p>
+</body>
+</html>

--- a/StandingsAndMatches.html
+++ b/StandingsAndMatches.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>TPL Standings and Matches</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
+    <div data-include="/nav.html"></div>
+
+  <div class="w-full max-w-4xl p-4">
+    <h1 class="text-2xl font-bold text-center mb-4">TPL Standings and Matches</h1>
+    <div class="flex flex-col md:flex-row gap-4 justify-center mb-6">
+      <div>
+        <label class="block text-sm mb-1">Season</label>
+        <select id="lmSeason" class="px-3 py-2 rounded-md bg-gray-700 border border-gray-600"></select>
+      </div>
+      <div>
+        <label class="block text-sm mb-1">Division</label>
+        <select id="lmDivision" class="px-3 py-2 rounded-md bg-gray-700 border border-gray-600"></select>
+      </div>
+    </div>
+
+    <div>
+      <h2 class="text-xl font-semibold mb-2">Standings</h2>
+      <table id="standingsTable" class="min-w-full text-left"></table>
+    </div>
+
+    <div class="mt-6">
+      <h2 class="text-xl font-semibold mb-2">Schedule</h2>
+      <div id="scheduleContainer"></div>
+    </div>
+  </div>
+
+  <script type="module">
+
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+    import { getFirestore, collection, getDocs, query, where } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
+      authDomain: "team-sign-up-b5646.firebaseapp.com",
+      projectId: "team-sign-up-b5646",
+      storageBucket: "team-sign-up-b5646.firebasestorage.app",
+      messagingSenderId: "951471144681",
+      appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getFirestore(app);
+
+
+    let seasonsIndex = [];
+    let currentSeasonData = null;
+
+    async function loadSeasons() {
+      const res = await fetch('seasons/index.json');
+      seasonsIndex = await res.json();
+      const seasonSelect = document.getElementById('lmSeason');
+      seasonsIndex.forEach(season => {
+        const opt = document.createElement('option');
+        opt.value = season.id;
+        opt.textContent = `Season ${season.id}`;
+        seasonSelect.appendChild(opt);
+      });
+      const active = seasonsIndex.filter(s => s.active).pop() || seasonsIndex[seasonsIndex.length - 1];
+      seasonSelect.value = active.id;
+      await loadSeasonData(active.id);
+    }
+
+    async function loadSeasonData(id) {
+      const seasonInfo = seasonsIndex.find(s => s.id == id);
+      if (!seasonInfo) return;
+      const res = await fetch(`seasons/${seasonInfo.file}`);
+      currentSeasonData = await res.json();
+      const divisionSelect = document.getElementById('lmDivision');
+      divisionSelect.innerHTML = '';
+      Object.keys(currentSeasonData.divisions).forEach(div => {
+        const opt = document.createElement('option');
+        opt.value = div;
+        opt.textContent = div;
+        divisionSelect.appendChild(opt);
+      });
+      divisionSelect.value = Object.keys(currentSeasonData.divisions)[0];
+
+      await renderDivision();
+    }
+
+    async function fetchTeams(season, division) {
+      const q = query(
+        collection(db, 'teams'),
+        where('season', '==', season),
+        where('division', '==', division),
+        where('approved', '==', true)
+      );
+      const snap = await getDocs(q);
+      return snap.docs.map(d => d.data());
+    }
+
+    async function renderDivision() {
+      const divKey = document.getElementById('lmDivision').value;
+      const divData = currentSeasonData.divisions[divKey];
+      const teams = await fetchTeams(currentSeasonData.season, divKey);
+      if (teams.length) {
+        const standings = teams.map(t => ({ team: t.teamName, wins: 0, losses: 0 }));
+        renderStandings(standings);
+      } else {
+        renderStandings(divData.standings);
+      }
+      renderSchedule(divData.schedule);
+    }
+
+    function renderStandings(rows) {
+      const table = document.getElementById('standingsTable');
+      table.innerHTML = '';
+      const header = document.createElement('tr');
+      header.innerHTML = '<th class="px-2">Team</th><th class="px-2">W</th><th class="px-2">L</th>';
+      table.appendChild(header);
+      rows.forEach(r => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td class="px-2">${r.team}</td><td class="px-2">${r.wins}</td><td class="px-2">${r.losses}</td>`;
+        table.appendChild(tr);
+      });
+    }
+
+    function renderSchedule(weeks) {
+      const container = document.getElementById('scheduleContainer');
+      container.innerHTML = '';
+      weeks.forEach(w => {
+        const div = document.createElement('div');
+        div.className = 'mb-4';
+        const title = document.createElement('h3');
+        title.className = 'font-semibold mb-1';
+        title.textContent = `Week ${w.week}`;
+        div.appendChild(title);
+        const ul = document.createElement('ul');
+        w.matches.forEach(m => {
+          const li = document.createElement('li');
+          li.textContent = `${m.date}: ${m.away} @ ${m.home}`;
+          ul.appendChild(li);
+        });
+        div.appendChild(ul);
+        container.appendChild(div);
+      });
+    }
+
+    document.getElementById('lmSeason').addEventListener('change', e => loadSeasonData(e.target.value));
+    document.getElementById('lmDivision').addEventListener('change', renderDivision);
+
+    loadSeasons();
+  </script>
+    <script src="/assets/include.js" defer></script>
+</body>
+</html>

--- a/TPLTeamsDashboard.html
+++ b/TPLTeamsDashboard.html
@@ -61,7 +61,7 @@
     </style>
 </head>
 <body class="bg-gray-900 text-white font-sans">
-    <div data-include="/nav.html"></div>
+    <div id="nav-placeholder"></div>
     <!-- Header -->
     <header class="bg-gray-800 py-6 shadow-lg">
         <div class="container mx-auto px-4 text-center">
@@ -535,14 +535,31 @@
             }
         });
     </script>
-    <script src="/assets/include.js" defer></script>
     <script>
-        document.addEventListener('includes-loaded', () => {
-            if (window.twitchOAuth) {
-                twitchOAuth.updateNav();
-                twitchOAuth.initLiveTeamsMenu();
+        async function loadNav() {
+            const placeholder = document.getElementById('nav-placeholder');
+            try {
+                const res = await fetch('nav.html');
+                if (!res.ok) throw new Error(`Nav fetch failed: ${res.status}`);
+                const html = await res.text();
+                placeholder.innerHTML = html;
+                placeholder.querySelectorAll('script').forEach(oldScript => {
+                    const newScript = document.createElement('script');
+                    [...oldScript.attributes].forEach(attr =>
+                        newScript.setAttribute(attr.name, attr.value)
+                    );
+                    newScript.textContent = oldScript.textContent;
+                    oldScript.replaceWith(newScript);
+                });
+                if (window.twitchOAuth) {
+                    window.twitchOAuth.updateNav();
+                    window.twitchOAuth.initLiveTeamsMenu();
+                }
+            } catch (err) {
+                console.error('Failed to load navigation', err);
             }
-        });
+        }
+        loadNav();
     </script>
 </body>
 </html>

--- a/nav.html
+++ b/nav.html
@@ -4,15 +4,15 @@
     <div class="flex h-16 items-center justify-between">
       <!-- Left: Brand -->
       <div class="flex items-center gap-3">
-        <a href="/index.html" class="flex items-center gap-2">
-          <img src="/assets/logo.svg" alt="TRL" class="h-8 w-8" onerror="this.style.display='none'">
-          <span class="text-white font-semibold tracking-wide">Tribes Rivals League</span>
+        <a href="TPLTeamsDashboard.html" class="flex items-center gap-2">
+          <img src="assets/logo.svg" alt="TPL" class="h-8 w-8" onerror="this.style.display='none'">
+          <span class="text-white font-semibold tracking-wide">Tribes Professional League</span>
         </a>
       </div>
 
       <!-- Desktop Nav -->
       <div class="hidden md:flex items-center gap-6">
-        <a href="/index.html" class="nav-link text-gray-200 hover:text-white">Home</a>
+        <a href="TPLTeamsDashboard.html" class="nav-link text-gray-200 hover:text-white">Home</a>
         <div class="relative group">
           <button class="text-gray-200 hover:text-white flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
             Teams
@@ -21,22 +21,64 @@
             </svg>
           </button>
           <div class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute mt-2 min-w-48 rounded-xl border border-gray-800 bg-gray-900 shadow-xl p-2">
-            <a href="/TPLTeamsDashboard.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
+            <a href="TPLTeamsDashboard.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
             <div class="my-2 h-px bg-gray-800"></div>
-            <a href="/TeamAV.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
-            <a href="/TeamFPS.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">FPS</a>
-            <a href="/TeamFT.html" class="block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">FT</a>
+            <a href="TeamAV.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
+            <a href="TeamDS.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
+            <a href="TeamDPRK.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">[DPRK] Team</a>
+            <a href="TeamEPI.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
+            <a href="TeamFPS.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
+            <a href="TeamFT.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
+            <a href="TeamHoE.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
+            <a href="TeamKTL.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
+            <a href="TeamMagic.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
+            <a href="TeamNull.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">null [null]</a>
+            <a href="TeamTXM.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
+            <a href="TeamToxicAimers.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
+            <a href="TeamUE.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
+            <a href="TeamZen.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
           </div>
         </div>
-        <a href="/Schedule.html" class="nav-link text-gray-200 hover:text-white">Schedule</a>
-        <a href="/Standings.html" class="nav-link text-gray-200 hover:text-white">Standings</a>
-        <a href="/Streamers.html" class="nav-link text-gray-200 hover:text-white">Streams</a>
+        <a href="StandingsAndMatches.html" class="nav-link text-gray-200 hover:text-white">Schedule</a>
+        <a href="StandingsAndMatches.html" class="nav-link text-gray-200 hover:text-white">Standings</a>
+        <div class="relative group">
+          <button class="text-gray-200 hover:text-white flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            TPL League
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute mt-2 min-w-48 rounded-xl border border-gray-800 bg-gray-900 shadow-xl p-2">
+            <a href="TeamSignUp.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Team Sign Up</a>
+            <a href="LeagueManager.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">League Manager</a>
+            <a href="UpcomingEvents.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Upcoming Events</a>
+            <a href="TournamentManager.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Tournament Manager</a>
+          </div>
+        </div>
+        <div class="relative group">
+          <button class="text-gray-200 hover:text-white flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            Streams
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <div class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute mt-2 min-w-48 rounded-xl border border-gray-800 bg-gray-900 shadow-xl p-2">
+            <a href="Streamers.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Streamers</a>
+            <div class="my-2 h-px bg-gray-800"></div>
+            <a href="TwitchFeedDisplays.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Twitch Feed Displays</a>
+            <a href="TwitchFeedMobile.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Twitch Feed Mobile</a>
+            <a href="TribesScrimWatcher.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">TPL Scrim Watcher</a>
+            <div class="my-2 h-px bg-gray-800"></div>
+            <a href="StreamersAdmin.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Streamers Admin</a>
+            <a href="StreamersSubmit.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Streamers Submit</a>
+          </div>
+        </div>
       </div>
 
       <!-- Right: CTA -->
       <div class="hidden md:flex items-center gap-3">
-        <a href="/DraftSignUp.html" class="px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium">Draft Sign-Up</a>
-        <a href="/LeagueManager.html" class="px-3 py-1.5 rounded-lg border border-gray-800 text-gray-200 hover:bg-gray-800 text-sm">Admin</a>
+        <a href="DraftSignUp.html" class="px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium">Draft Sign-Up</a>
+        <a href="LeagueManager.html" class="px-3 py-1.5 rounded-lg border border-gray-800 text-gray-200 hover:bg-gray-800 text-sm">Admin</a>
       </div>
 
       <!-- Mobile hamburger -->
@@ -54,7 +96,7 @@
   <!-- Mobile panel -->
   <div id="mobile-menu" class="md:hidden hidden border-t border-gray-800">
     <div class="space-y-1 px-4 py-3">
-      <a href="/index.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Home</a>
+      <a href="TPLTeamsDashboard.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Home</a>
       <details class="group">
         <summary class="flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">
           <span>Teams</span>
@@ -63,25 +105,65 @@
           </svg>
         </summary>
         <div class="mt-1 pl-3 space-y-1">
-          <a href="/TPLTeamsDashboard.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
-          <a href="/TeamAV.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
-          <a href="/TeamFPS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">FPS</a>
-          <a href="/TeamFT.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">FT</a>
+          <a href="TPLTeamsDashboard.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
+          <a href="TeamAV.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
+          <a href="TeamDS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
+          <a href="TeamDPRK.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">[DPRK] Team</a>
+          <a href="TeamEPI.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
+          <a href="TeamFPS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
+          <a href="TeamFT.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
+          <a href="TeamHoE.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
+          <a href="TeamKTL.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
+          <a href="TeamMagic.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
+          <a href="TeamNull.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">null [null]</a>
+          <a href="TeamTXM.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
+          <a href="TeamToxicAimers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
+          <a href="TeamUE.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
+          <a href="TeamZen.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
         </div>
       </details>
-      <a href="/Schedule.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Schedule</a>
-      <a href="/Standings.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Standings</a>
-      <a href="/Streamers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streams</a>
+      <a href="StandingsAndMatches.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Schedule</a>
+      <a href="StandingsAndMatches.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Standings</a>
+      <details class="group">
+        <summary class="flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">
+          <span>TPL League</span>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 group-open:rotate-180 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </summary>
+        <div class="mt-1 pl-3 space-y-1">
+          <a href="TeamSignUp.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Team Sign Up</a>
+          <a href="LeagueManager.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">League Manager</a>
+          <a href="UpcomingEvents.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Upcoming Events</a>
+          <a href="TournamentManager.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Tournament Manager</a>
+        </div>
+      </details>
+      <details class="group">
+        <summary class="flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">
+          <span>Streams</span>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 group-open:rotate-180 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </summary>
+        <div class="mt-1 pl-3 space-y-1">
+          <a href="Streamers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streamers</a>
+          <a href="TwitchFeedDisplays.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Twitch Feed Displays</a>
+          <a href="TwitchFeedMobile.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Twitch Feed Mobile</a>
+          <a href="TribesScrimWatcher.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">TPL Scrim Watcher</a>
+          <a href="StreamersAdmin.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streamers Admin</a>
+          <a href="StreamersSubmit.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Streamers Submit</a>
+        </div>
+      </details>
       <div class="pt-2">
-        <a href="/DraftSignUp.html" class="block rounded-lg px-3 py-2 bg-indigo-600 hover:bg-indigo-500 text-white">Draft Sign-Up</a>
-        <a href="/LeagueManager.html" class="block rounded-lg mt-1 px-3 py-2 border border-gray-800 text-gray-200 hover:bg-gray-800">Admin</a>
+        <a href="DraftSignUp.html" class="block rounded-lg px-3 py-2 bg-indigo-600 hover:bg-indigo-500 text-white">Draft Sign-Up</a>
+        <a href="LeagueManager.html" class="block rounded-lg mt-1 px-3 py-2 border border-gray-800 text-gray-200 hover:bg-gray-800">Admin</a>
       </div>
     </div>
   </div>
 </nav>
 
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
+  function initNav() {
     // Mobile toggle
     const toggle = document.getElementById('nav-toggle');
     const menu = document.getElementById('mobile-menu');
@@ -94,14 +176,20 @@
     }
 
     // Highlight active link
-    const path = location.pathname.replace(/\\/index\\.html$/, '/');
+    const path = location.pathname.replace(/\/index\.html$/, '/');
     document.querySelectorAll('a.nav-link, #mobile-menu a').forEach(a => {
       try {
         const aPath = new URL(a.href, location.origin).pathname;
         if (aPath === location.pathname || (aPath.endsWith('/index.html') && path === '/')) {
-          a.classList.add('text-white','font-semibold');
+          a.classList.add('text-white', 'font-semibold');
         }
       } catch {}
     });
-  });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initNav);
+  } else {
+    initNav();
+  }
 </script>


### PR DESCRIPTION
## Summary
- Rename LeagueManager standings viewer to StandingsAndMatches and point Standings/Schedule links to it
- Introduce a new League Manager page to build schedules, record scores, and compute standings in Firestore
- Document new pages and links in the README

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689768e928e8832a93f9d2941807b3c9