### PR TITLE
Add navigation bar to remaining pages and remove from team pages

### DIFF
--- a/Schedule.html
+++ b/Schedule.html
@@ -6,6 +6,8 @@
   <title>Schedule</title>
 </head>
 <body class="bg-gray-900 text-white">
+  <div data-include="/nav.html"></div>
   <p class="p-4">Redirecting to <a href="StandingsAndMatches.html">Standings and Matches</a>...</p>
+  <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/Standings.html
+++ b/Standings.html
@@ -6,6 +6,8 @@
   <title>Standings</title>
 </head>
 <body class="bg-gray-900 text-white">
+  <div data-include="/nav.html"></div>
   <p class="p-4">Redirecting to <a href="StandingsAndMatches.html">Standings and Matches</a>...</p>
+  <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamAV.html
+++ b/TeamAV.html
@@ -86,7 +86,6 @@
     </style>
 </head>
 <body class="gradient-bg text-white font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="bg-gray-900 bg-opacity-90 p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -227,6 +226,5 @@
             <p>Follow us on <a href="wwww.team-avalanche.online" target="_blank" class="text-red-400 hover:text-red-300">@Avalanche</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamDPRK.html
+++ b/TeamDPRK.html
@@ -225,7 +225,6 @@
     </script>
 </head>
 <body>
-    <div data-include="/nav.html"></div>
     <header>
         <img src="https://github.com/T24085/TeamDPRK/blob/main/TeamDPRKLogo3.png?raw=true" alt="DPRK Logo">
         <h1>[DPRK] TPL</h1>
@@ -420,6 +419,5 @@
         <p>© 2025 [DPRK] Tribes Professional League. All rights reserved.</p>
         <img src="https://github.com/T24085/TeamDPRK/blob/main/DPRKLOGO.png?raw=true" alt="DPRK Logo">
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamDS.html
+++ b/TeamDS.html
@@ -157,7 +157,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -323,6 +322,5 @@
             <p>Follow us on <a href="https://x.com/DS" target="_blank" class="text-gray-300 hover:text-gray-400">@DS</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamEPI.html
+++ b/TeamEPI.html
@@ -86,7 +86,6 @@
     </style>
 </head>
 <body class="gradient-bg text-white font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="bg-gray-900 bg-opacity-90 p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -202,6 +201,5 @@
             <p>Follow us on <a href="https://x.com/Epidemic" target="_blank" class="text-purple-300 hover:text-purple-200">@Epidemic</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamFPS.html
+++ b/TeamFPS.html
@@ -152,7 +152,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -304,6 +303,5 @@
             <p>Follow us on <a href="https://x.com/FPS" target="_blank" class="text-red-300 hover:text-red-200">@FPS</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamFT.html
+++ b/TeamFT.html
@@ -153,7 +153,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -308,6 +307,5 @@
             <p>Follow us on <a href="https://x.com/FlyingTractors" target="_blank" class="text-green-300 hover:text-green-200">@FlyingTractors</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamHoE.html
+++ b/TeamHoE.html
@@ -113,7 +113,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-serif">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -287,6 +286,5 @@
             <p>Follow us on <a href="https://x.com/HoE" target="_blank" class="text-yellow-400 hover:text-yellow-300">@HoE</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamKTL.html
+++ b/TeamKTL.html
@@ -152,7 +152,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -277,6 +276,5 @@
             <p>Follow us on <a href="https://x.com/KTL" target="_blank" class="text-cyan-300 hover:text-cyan-200">@KTL</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamMagic.html
+++ b/TeamMagic.html
@@ -153,7 +153,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-serif">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -306,6 +305,5 @@
             <p>Follow us on <a href="https://x.com/Magic" target="_blank" class="text-yellow-400 hover:text-yellow-300">@Magic</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamNull.html
+++ b/TeamNull.html
@@ -153,7 +153,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -279,6 +278,5 @@
             <p>Follow us on <a href="https://x.com/NULL" target="_blank" class="text-green-300 hover:text-green-200">@NULL</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamTXM.html
+++ b/TeamTXM.html
@@ -91,7 +91,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -262,6 +261,5 @@
             <p>Follow us on <a href="https://x.com/TXM" target="_blank" class="text-blue-300 hover:text-blue-200">@TXM</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamToxicAimers.html
+++ b/TeamToxicAimers.html
@@ -153,7 +153,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -310,6 +309,5 @@
             <p>Follow us on <a href="https://x.com/ToxicAimers" target="_blank" class="text-green-300 hover:text-purple-400">@ToxicAimers</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamUE.html
+++ b/TeamUE.html
@@ -153,7 +153,6 @@
     </style>
 </head>
 <body class="gradient-bg text-gray-100 font-mono">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -272,6 +271,5 @@
             <p>Follow us on <a href="https://x.com/UE" target="_blank" class="text-red-400 hover:text-red-300">@UE</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamZen.html
+++ b/TeamZen.html
@@ -103,7 +103,6 @@
     </style>
 </head>
 <body class="gradient-bg text-cream-100 font-sans">
-    <div data-include="/nav.html"></div>
     <!-- Header Section -->
     <header class="header-footer-bg p-6 sticky top-0 z-10">
         <div class="container mx-auto flex justify-between items-center">
@@ -240,6 +239,5 @@
             <p>Follow us on <a href="https://x.com/ZEN" target="_blank" class="text-orange-300 hover:text-orange-200">@ZEN</a></p>
         </div>
     </footer>
-    <script src="/assets/include.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load shared navigation on Schedule and Standings pages
- drop shared navigation and include.js from individual team pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897ada64d6c832a890eeb31dea01ccf