### PR TITLE
fix: stabilize Twitch auth handling

### DIFF
--- a/oauth.js
+++ b/oauth.js
@@ -1,7 +1,7 @@
 (function(){
   const CLIENT_ID = 'meabi1n42pccff5rz9ujpno7ky9vlt';
-  // Redirect back to the page the user is on after Twitch auth
-  const REDIRECT_URI = window.location.origin + window.location.pathname;
+  // Always return to the new TPL dashboard after Twitch auth
+  const REDIRECT_URI = `${window.location.origin}/TPLTeamsDashboard.html`;
   const STORAGE_KEY = 'twitch_token';
 
   const TEAM_STREAMS = {
@@ -94,6 +94,10 @@
           'Client-Id': CLIENT_ID,
         }
       });
+      if (!res.ok) {
+        if (res.status === 401) clearToken();
+        return null;
+      }
       const json = await res.json();
       return json.data && json.data.length ? json.data[0] : null;
     } catch (err) {
@@ -113,6 +117,10 @@
           'Client-Id': CLIENT_ID,
         }
       });
+      if (!res.ok) {
+        if (res.status === 401) clearToken();
+        return [];
+      }
       const json = await res.json();
       return json.data || [];
     } catch (err) {
@@ -128,10 +136,14 @@
     try {
       const res = await fetch('https://api.twitch.tv/helix/streams?' + query, {
         headers: {
-          'Client-ID': CLIENT_ID,
+          'Client-Id': CLIENT_ID,
           'Authorization': 'Bearer ' + token
         }
       });
+      if (!res.ok) {
+        if (res.status === 401) clearToken();
+        return [];
+      }
       const json = await res.json();
       return Array.isArray(json.data) ? json.data : [];
     } catch (err) {
@@ -269,7 +281,8 @@
       `?client_id=${CLIENT_ID}` +
       `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
       '&response_type=token' +
-      `&scope=${encodeURIComponent(scope)}`;
+      `&scope=${encodeURIComponent(scope)}` +
+      '&force_verify=true';
     window.location.href = url;
   }
 


### PR DESCRIPTION
## Summary
- handle invalid Twitch tokens by clearing localStorage on 401 responses
- standardize Client-Id header usage across Helix API requests
- force re-verification during OAuth login to ensure required scopes
- always redirect Twitch login flow to the new TPL dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897adcc92b0832a9affb6447f17de46