### PR TITLE
Fix nav in TPL dashboard

### DIFF
--- a/DraftSignUp.html
+++ b/DraftSignUp.html
@@ -73,7 +73,7 @@
   </style>
 </head>
 <body class="text-white">
-    <div data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="/nav.html"></div>
   <div id="root"></div>
   <script type="text/babel">
     const POSITIONS = ['HoF', 'LD', 'MD', 'MO', 'HO', 'LO', 'Capper'];
@@ -422,6 +422,29 @@
     const root = ReactDOM.createRoot(document.getElementById('root'));
     root.render(<App />);
   </script>
-    <script src="/assets/include.js" defer></script>
-</body>
+    <script>
+      async function loadNav() {
+        const placeholder = document.getElementById('nav-placeholder');
+        try {
+          const res = await fetch('./nav.html');
+          if (!res.ok) throw new Error(`Nav fetch failed: ${res.status}`);
+          const html = await res.text();
+          placeholder.innerHTML = html;
+          placeholder.querySelectorAll('script').forEach(oldScript => {
+            const newScript = document.createElement('script');
+            [...oldScript.attributes].forEach(attr => newScript.setAttribute(attr.name, attr.value));
+            newScript.textContent = oldScript.textContent;
+            oldScript.replaceWith(newScript);
+          });
+          if (window.twitchOAuth) {
+            window.twitchOAuth.updateNav();
+            window.twitchOAuth.initLiveTeamsMenu();
+          }
+        } catch (err) {
+          console.error('Failed to load navigation', err);
+        }
+      }
+      loadNav();
+    </script>
+  </body>
 </html>

--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
-  <div data-include="/nav.html"></div>
+  <div id="nav-placeholder" data-include="/nav.html"></div>
 
   <div id="loginDiv" class="max-w-sm mx-auto mt-10 space-y-4">
     <h1 class="text-2xl font-bold text-center">Admin Login</h1>
@@ -336,6 +336,29 @@
     await loadSeasons();
   });
 </script>
-  <script src="/assets/include.js" defer></script>
+  <script>
+    async function loadNav() {
+      const placeholder = document.getElementById('nav-placeholder');
+      try {
+        const res = await fetch('./nav.html');
+        if (!res.ok) throw new Error(`Nav fetch failed: ${res.status}`);
+        const html = await res.text();
+        placeholder.innerHTML = html;
+        placeholder.querySelectorAll('script').forEach(oldScript => {
+          const newScript = document.createElement('script');
+          [...oldScript.attributes].forEach(attr => newScript.setAttribute(attr.name, attr.value));
+          newScript.textContent = oldScript.textContent;
+          oldScript.replaceWith(newScript);
+        });
+        if (window.twitchOAuth) {
+          window.twitchOAuth.updateNav();
+          window.twitchOAuth.initLiveTeamsMenu();
+        }
+      } catch (err) {
+        console.error('Failed to load navigation', err);
+      }
+    }
+    loadNav();
+  </script>
 </body>
 </html>

--- a/StandingsAndMatches.html
+++ b/StandingsAndMatches.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
-    <div data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="/nav.html"></div>
 
   <div class="w-full max-w-4xl p-4">
     <h1 class="text-2xl font-bold text-center mb-4">TPL Standings and Matches</h1>
@@ -180,6 +180,29 @@
 
     loadSeasons();
   </script>
-    <script src="/assets/include.js" defer></script>
-</body>
+    <script>
+      async function loadNav() {
+        const placeholder = document.getElementById('nav-placeholder');
+        try {
+          const res = await fetch('./nav.html');
+          if (!res.ok) throw new Error(`Nav fetch failed: ${res.status}`);
+          const html = await res.text();
+          placeholder.innerHTML = html;
+          placeholder.querySelectorAll('script').forEach(oldScript => {
+            const newScript = document.createElement('script');
+            [...oldScript.attributes].forEach(attr => newScript.setAttribute(attr.name, attr.value));
+            newScript.textContent = oldScript.textContent;
+            oldScript.replaceWith(newScript);
+          });
+          if (window.twitchOAuth) {
+            window.twitchOAuth.updateNav();
+            window.twitchOAuth.initLiveTeamsMenu();
+          }
+        } catch (err) {
+          console.error('Failed to load navigation', err);
+        }
+      }
+      loadNav();
+    </script>
+  </body>
 </html>

--- a/TPLTeamsDashboard.html
+++ b/TPLTeamsDashboard.html
@@ -61,7 +61,7 @@
     </style>
 </head>
     <body class="bg-gray-900 text-white font-sans">
-      <div data-include="/nav.html"></div>
+      <div id="nav-placeholder" data-include="/nav.html"></div>
     <!-- Header -->
     <header class="bg-gray-800 py-6 shadow-lg">
         <div class="container mx-auto px-4 text-center">

--- a/nav.html
+++ b/nav.html
@@ -176,7 +176,7 @@
     text-align: center;
     font-size: 1rem;
     animation: lab-glow 2s ease-in-out infinite alternate;
-    z-index: 1000;
+    z-index: 40;
   }
   @keyframes lab-glow {
     from {


### PR DESCRIPTION
## Summary
- Ensure TPL dashboard includes nav by adding placeholder element for dynamic loading
- Load shared nav dynamically in LeagueManager, DraftSignUp, and StandingsAndMatches pages
- Lower live announcement banner z-index so it no longer blocks navigation dropdowns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d11b2bc8832a99359c6157a36d77