### PR TITLE
Add navigation bar to sign-up and events pages

### DIFF
--- a/TeamSignUp.html
+++ b/TeamSignUp.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
-    <div data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="/nav.html"></div>
 
 
   <div class="bg-gray-800 shadow-lg rounded-2xl p-8 w-full max-w-2xl mt-8">
@@ -195,6 +195,29 @@
     });
   </script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
-    <script src="/assets/include.js" defer></script>
+  <script>
+    async function loadNav() {
+      const placeholder = document.getElementById('nav-placeholder');
+      try {
+        const res = await fetch('./nav.html');
+        if (!res.ok) throw new Error(`Nav fetch failed: ${res.status}`);
+        const html = await res.text();
+        placeholder.innerHTML = html;
+        placeholder.querySelectorAll('script').forEach(oldScript => {
+          const newScript = document.createElement('script');
+          [...oldScript.attributes].forEach(attr => newScript.setAttribute(attr.name, attr.value));
+          newScript.textContent = oldScript.textContent;
+          oldScript.replaceWith(newScript);
+        });
+        if (window.twitchOAuth) {
+          window.twitchOAuth.updateNav();
+          window.twitchOAuth.initLiveTeamsMenu();
+        }
+      } catch (err) {
+        console.error('Failed to load navigation', err);
+      }
+    }
+    loadNav();
+  </script>
 </body>
 </html>

--- a/UpcomingEvents.html
+++ b/UpcomingEvents.html
@@ -8,12 +8,35 @@
     <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white">
-    <div data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="/nav.html"></div>
     <main class="container mx-auto p-4">
         <h1 class="text-3xl font-bold mb-4 text-center">Upcoming Events</h1>
         <img src="Twin.jpg" alt="Twins" class="mx-auto mb-4 max-w-xs">
         <iframe class="w-full h-[75vh] bg-white" src="https://docs.google.com/document/d/1wkWiFoTMbQoMkguv-cMBVqpg3hZzY0RJrZ9egVOWoNo/preview"></iframe>
     </main>
-    <script src="/assets/include.js" defer></script>
+    <script>
+      async function loadNav() {
+        const placeholder = document.getElementById('nav-placeholder');
+        try {
+          const res = await fetch('./nav.html');
+          if (!res.ok) throw new Error(`Nav fetch failed: ${res.status}`);
+          const html = await res.text();
+          placeholder.innerHTML = html;
+          placeholder.querySelectorAll('script').forEach(oldScript => {
+            const newScript = document.createElement('script');
+            [...oldScript.attributes].forEach(attr => newScript.setAttribute(attr.name, attr.value));
+            newScript.textContent = oldScript.textContent;
+            oldScript.replaceWith(newScript);
+          });
+          if (window.twitchOAuth) {
+            window.twitchOAuth.updateNav();
+            window.twitchOAuth.initLiveTeamsMenu();
+          }
+        } catch (err) {
+          console.error('Failed to load navigation', err);
+        }
+      }
+      loadNav();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load shared navigation in Team Sign-Up page
- Load shared navigation in Upcoming Events page

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b4c71a4832a8d703c574bcca59b