### PR TITLE
feat: add nav bar to Twitch feed displays

### DIFF
--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -299,7 +299,7 @@
   </style>
 </head>
 <body>
-    <div data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="/nav.html"></div>
   <div class="container">
     <header>
       <div class="form-section">
@@ -669,6 +669,32 @@
     if (liveBtn) liveBtn.textContent = showOnlyLive ? 'Show All Channels' : 'Show Only Live';
     updateLiveChannels();
   </script>
-    <script src="/assets/include.js" defer></script>
+  <script>
+    async function loadNav() {
+      const placeholder = document.getElementById('nav-placeholder');
+      if (!placeholder) return;
+      try {
+        const res = await fetch('./nav.html');
+        if (!res.ok) throw new Error('Nav fetch failed: ' + res.status);
+        const html = await res.text();
+        placeholder.innerHTML = html;
+        placeholder.querySelectorAll('script').forEach(oldScript => {
+          const newScript = document.createElement('script');
+          [...oldScript.attributes].forEach(attr => newScript.setAttribute(attr.name, attr.value));
+          newScript.textContent = oldScript.textContent;
+          oldScript.replaceWith(newScript);
+        });
+        if (window.twitchOAuth) {
+          window.twitchOAuth.updateNav();
+          if (window.twitchOAuth.initLiveTeamsMenu) {
+            window.twitchOAuth.initLiveTeamsMenu();
+          }
+        }
+      } catch (err) {
+        console.error('Failed to load navigation', err);
+      }
+    }
+    loadNav();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load shared navigation menu into Twitch feed displays page

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0bda6858832aa7fa24c829e59d61