### PR TITLE
fix: restore nav dropdowns on league manager and standings pages

### DIFF
--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>TPL League Manager</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">

--- a/StandingsAndMatches.html
+++ b/StandingsAndMatches.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>TPL Standings and Matches</title>
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">


### PR DESCRIPTION
## Summary
- load Tailwind via the CDN script so the nav dropdowns work on League Manager and Standings & Matches

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0ba73664832a998fe89684c4ed66