### PR TITLE
feat: display postseason schedule

### DIFF
--- a/StandingsAndMatches.html
+++ b/StandingsAndMatches.html
@@ -156,12 +156,30 @@
     function renderSchedule(weeks) {
       const container = document.getElementById('scheduleContainer');
       container.innerHTML = '';
+      let currentPhase = 'regular';
       weeks.forEach(w => {
+        const phase = w.phase || 'regular';
+        if (phase !== currentPhase) {
+          if (phase !== 'regular') {
+            const heading = document.createElement('h3');
+            heading.className = 'text-lg font-semibold mt-4 mb-2';
+            heading.textContent = phase === 'playoffs' ? 'Playoffs' : 'Championship';
+            container.appendChild(heading);
+          }
+          currentPhase = phase;
+        }
+
         const div = document.createElement('div');
         div.className = 'mb-4';
-        const title = document.createElement('h3');
+        const title = document.createElement('h4');
         title.className = 'font-semibold mb-1';
-        title.textContent = `Week ${w.week}`;
+        if (phase === 'regular') {
+          title.textContent = `Week ${w.week}`;
+        } else if (phase === 'playoffs') {
+          title.textContent = `Round ${w.week}`;
+        } else {
+          title.textContent = 'Finals';
+        }
         div.appendChild(title);
         const ul = document.createElement('ul');
         w.matches.forEach(m => {


### PR DESCRIPTION
## Summary
- group schedule by phase to display Playoffs and Championship sections
- show round and finals labels instead of weeks in postseason

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a10cdd6bc832a9d24bb9b8faecb24