### PR TITLE
Add phase selection to league schedule weeks

### DIFF
--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -199,16 +199,41 @@
       const div = document.createElement('div');
       div.className = 'border border-gray-700 p-3 rounded-md';
       div.dataset.week = w.week;
+      const phase = w.phase || 'regular';
+      div.dataset.phase = phase;
+
       const header = document.createElement('div');
       header.className = 'flex justify-between items-center mb-2';
+
+      const left = document.createElement('div');
+      left.className = 'flex items-center gap-2';
+
       const title = document.createElement('h3');
       title.className = 'font-semibold';
       title.textContent = `Week ${w.week}`;
+
+      const phaseSelect = document.createElement('select');
+      phaseSelect.className = 'px-2 py-1 rounded bg-gray-800 border border-gray-700';
+      ['regular', 'playoffs', 'championship'].forEach(p => {
+        const opt = document.createElement('option');
+        opt.value = p;
+        opt.textContent = p.charAt(0).toUpperCase() + p.slice(1);
+        if (p === phase) opt.selected = true;
+        phaseSelect.appendChild(opt);
+      });
+      phaseSelect.addEventListener('change', () => {
+        div.dataset.phase = phaseSelect.value;
+      });
+
+      left.append(title, phaseSelect);
+
       const addBtn = document.createElement('button');
       addBtn.textContent = 'Add Match';
       addBtn.className = 'addMatch px-2 py-1 bg-gray-700 rounded';
-      header.append(title, addBtn);
+
+      header.append(left, addBtn);
       div.appendChild(header);
+
       const matchesContainer = document.createElement('div');
       matchesContainer.className = 'space-y-2';
       (w.matches || []).forEach(m => matchesContainer.appendChild(createMatchRow(m)));
@@ -220,6 +245,7 @@
   function gatherSchedule() {
     return Array.from(document.querySelectorAll('#weeksContainer > div')).map(div => ({
       week: Number(div.dataset.week),
+      phase: div.dataset.phase || 'regular',
       matches: Array.from(div.querySelectorAll('.flex.flex-wrap')).map(row => {
         const [date, awaySel, homeSel, awayScore, homeScore] = row.querySelectorAll('input, select');
         return {
@@ -237,7 +263,7 @@
     const existing = gatherSchedule();
     const start = existing.length + 1;
     for (let i = 0; i < num; i++) {
-      existing.push({ week: start + i, matches: [] });
+      existing.push({ week: start + i, phase: 'regular', matches: [] });
     }
     renderWeeks(existing);
   }


### PR DESCRIPTION
## Summary
- Add per-week phase selector (regular/playoffs/championship) with default `regular`
- Persist selected phase for each week in saved schedules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a10ca606c832a83e2fab044dea026