### PR TITLE
Exclude non-regular phase matches from standings

### DIFF
--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -245,17 +245,20 @@
   function computeStandings(schedule) {
     const table = {};
     teams.forEach(t => (table[t] = { team: t, wins: 0, losses: 0 }));
-    schedule.forEach(w => w.matches.forEach(m => {
-      if (m.homeScore != null && m.awayScore != null) {
-        if (m.homeScore > m.awayScore) {
-          table[m.home].wins++;
-          table[m.away].losses++;
-        } else if (m.awayScore > m.homeScore) {
-          table[m.away].wins++;
-          table[m.home].losses++;
+    schedule.forEach(w => {
+      if (w.phase && w.phase !== 'regular') return;
+      w.matches.forEach(m => {
+        if (m.homeScore != null && m.awayScore != null) {
+          if (m.homeScore > m.awayScore) {
+            table[m.home].wins++;
+            table[m.away].losses++;
+          } else if (m.awayScore > m.homeScore) {
+            table[m.away].wins++;
+            table[m.home].losses++;
+          }
         }
-      }
-    }));
+      });
+    });
     return Object.values(table);
   }
 

--- a/StandingsAndMatches.html
+++ b/StandingsAndMatches.html
@@ -126,17 +126,20 @@
     function computeStandings(weeks, teams) {
       const table = {};
       teams.forEach(t => (table[t] = { team: t, wins: 0, losses: 0 }));
-      weeks.forEach(w => w.matches.forEach(m => {
-        if (m.homeScore != null && m.awayScore != null) {
-          if (m.homeScore > m.awayScore) {
-            table[m.home].wins++;
-            table[m.away].losses++;
-          } else if (m.awayScore > m.homeScore) {
-            table[m.away].wins++;
-            table[m.home].losses++;
+      weeks.forEach(w => {
+        if (w.phase && w.phase !== 'regular') return;
+        w.matches.forEach(m => {
+          if (m.homeScore != null && m.awayScore != null) {
+            if (m.homeScore > m.awayScore) {
+              table[m.home].wins++;
+              table[m.away].losses++;
+            } else if (m.awayScore > m.homeScore) {
+              table[m.away].wins++;
+              table[m.home].losses++;
+            }
           }
-        }
-      }));
+        });
+      });
       return Object.values(table);
     }
 


### PR DESCRIPTION
## Summary
- Skip matches from non-regular phase weeks when computing standings in LeagueManager and StandingsAndMatches

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a10cdbc9c832aac91f388cd13743e