### PR TITLE
Fix Twitch OAuth redirect path

### DIFF
--- a/oauth.js
+++ b/oauth.js
@@ -1,7 +1,13 @@
 (function(){
   const CLIENT_ID = 'meabi1n42pccff5rz9ujpno7ky9vlt';
-  // Always return to the new TPL dashboard after Twitch auth
-  const REDIRECT_URI = `${window.location.origin}/TPLTeamsDashboard.html`;
+  // Always return to the new TPL dashboard after Twitch auth.
+  // Build the redirect path relative to the current directory so GitHub Pages
+  // deployments (which include the repo name in the URL) are handled
+  // correctly.
+  const basePath =
+    window.location.origin +
+    window.location.pathname.replace(/\/[^/]*$/, '/');
+  const REDIRECT_URI = `${basePath}TPLTeamsDashboard.html`;
   const STORAGE_KEY = 'twitch_token';
 
   const TEAM_STREAMS = {


### PR DESCRIPTION
## Summary
- Fix Twitch sign-in redirect by computing full path to TPL dashboard relative to current URL
- Add explanatory comments around redirect handling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const window = { location: { origin: 'https://t24085.github.io', pathname: '/ProjectTribes/Schedule.html' } }; const basePath = window.location.origin + window.location.pathname.replace(/\\/[^/]*$/, '/'); const redirectUri = `${basePath}TPLTeamsDashboard.html`; console.log(redirectUri);"`

------
https://chatgpt.com/codex/tasks/task_e_689a188f4798832ab898fedb3edc3ed3