### PR TITLE
Add news page and navigation link

### DIFF
--- a/News.html
+++ b/News.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>News</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen">
+  <div id="nav-placeholder" data-include="/nav.html"></div>
+
+  <main class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold mb-6">News</h1>
+    <ul id="newsList" class="space-y-6"></ul>
+  </main>
+
+  <script src="/assets/include.js" defer></script>
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+    import { getFirestore, collection, getDocs, orderBy, query } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
+      authDomain: "team-sign-up-b5646.firebaseapp.com",
+      projectId: "team-sign-up-b5646",
+      storageBucket: "team-sign-up-b5646.firebasestorage.app",
+      messagingSenderId: "951471144681",
+      appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getFirestore(app);
+
+    const list = document.getElementById('newsList');
+
+    function formatDate(ts) {
+      if (!ts) return '';
+      let date;
+      if (typeof ts.toDate === 'function') {
+        date = ts.toDate();
+      } else {
+        date = new Date(ts);
+      }
+      return date.toLocaleDateString();
+    }
+
+    async function loadNews() {
+      const newsQuery = query(collection(db, 'news'), orderBy('timestamp', 'desc'));
+      const snapshot = await getDocs(newsQuery);
+      snapshot.forEach(doc => {
+        const data = doc.data();
+        const li = document.createElement('li');
+        li.className = 'bg-gray-800 p-4 rounded-lg';
+        li.innerHTML = `
+          <h2 class="text-xl font-semibold">${data.title || ''}</h2>
+          <p class="text-sm text-gray-400 mb-2">${formatDate(data.timestamp)}</p>
+          <p class="whitespace-pre-line">${data.body || ''}</p>
+        `;
+        list.appendChild(li);
+      });
+    }
+
+    loadNews();
+  </script>
+</body>
+</html>

--- a/nav.html
+++ b/nav.html
@@ -42,6 +42,7 @@
         </div>
         <a href="StandingsAndMatches.html" class="nav-link text-gray-200 hover:text-white">Schedule</a>
         <a href="StandingsAndMatches.html" class="nav-link text-gray-200 hover:text-white">Standings</a>
+        <a href="News.html" class="nav-link text-gray-200 hover:text-white">News</a>
         <div class="relative group">
           <button class="text-gray-200 hover:text-white flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
             TPL League
@@ -127,6 +128,7 @@
       </details>
       <a href="StandingsAndMatches.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Schedule</a>
       <a href="StandingsAndMatches.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Standings</a>
+      <a href="News.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">News</a>
       <details class="group">
         <summary class="flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">
           <span>TPL League</span>


### PR DESCRIPTION
## Summary
- add News page loading posts from Firestore
- link News in navbar for desktop and mobile views

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ProjectTribes/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a1fa25d24832ab5c57688334ebfe7