### PR TITLE
Remove DeadStop and Viva teams from dashboard

### DIFF
--- a/TPLTeamsDashboard.html
+++ b/TPLTeamsDashboard.html
@@ -215,31 +215,6 @@
                     <button onclick="showRoster('Toxic Aimers')" class="mt-2 bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded">View Roster</button>
                 </div>
             </div>
-            <!-- DeadStop -->
-            <div class="team-card bg-gray-800 rounded-lg overflow-hidden shadow-lg">
-                <a href="https://t24085.github.io/TribesProfessionalLeague/TeamDS.html">
-
-                    <img src="images/DeadStopLogo.png" alt="DeadStop team logo with calming tribal design" class="w-full h-48 object-cover">
-
-                </a>
-                <div class="p-4 text-center">
-                    <h3 class="text-xl font-bold">DeadStop [DS]<span id="live-DeadStop" class="live-indicator ml-2 text-green-400 font-bold">LIVE</span></h3>
-                    <p class="text-gray-400">Captain: Blitz</p>
-                    <button onclick="showRoster('DeadStop')" class="mt-2 bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded">View Roster</button>
-                    <button onclick="showStreams('DeadStop')" class="mt-2 bg-green-600 hover:bg-green-700 text-white py-2 px-4 rounded">Streams</button>
-                </div>
-            </div>
-            <!-- Viva la Revolución -->
-            <div class="team-card bg-gray-800 rounded-lg overflow-hidden shadow-lg">
-                <a href="https://t24085.github.io/Team-R/" target="_blank">
-                    <img src="images/Rlogo.png" alt="Viva la Revolución team logo with revolutionary tribal symbols" class="w-full h-48 object-cover">
-                </a>
-                <div class="p-4 text-center">
-                    <h3 class="text-xl font-bold">Viva la Revolución [R]<span id="live-Viva-la-Revolución" class="live-indicator ml-2 text-green-400 font-bold">LIVE</span></h3>
-                    <p class="text-gray-400">Captain: @Borpalkitty</p>
-                    <button onclick="showRoster('Viva la Revolución')" class="mt-2 bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded">View Roster</button>
-                </div>
-            </div>
             <!-- UE -->
             <div class="team-card bg-gray-800 rounded-lg overflow-hidden shadow-lg">
                 <a href="https://t24085.github.io/Team-UE/" target="_blank">
@@ -353,8 +328,6 @@
             'Magic': 'Captain: @[wiz] Lange\nCore: Rebeltrooper, XRY, Dust, Cinnamon, Songsteal, Sek, SplitSecond\nBench: Snakke, Lester',
             'null': 'Captain: @_...\nCore: Blaspheme, Annaberries, xQ, muuki, exhumaxer, corbeling, mikeax2\nBench: ryan',
             'Toxic Aimers': 'Captain: @R...\nCore: Song, Sek, Hatuey, DareDevilMoon, Nerve, Radishblue, Trey\nBench: Sin, Stork',
-            'DeadStop': 'Captain: Blitz\nCore: apc, Hosh, Luna, Rock, Rell, Iinferno, Makasuro, CheesyDean, ContingencyPlan\nBench: Nykie4Life',
-            'Viva la Revolución': 'Captain: @Borpalkitty\nCore: Visis, Barthy, OperationCats, Jive, Oo 0 oO, Hitch, Zack, Kadenzah',
             'UE': 'DeadManWalking, Pablo, TTVfoenixx, Loot, Nykie4life, Stimzees, The Quacken .'
         };
 
@@ -410,11 +383,6 @@
                 { name: 'XRY', url: 'https://www.twitch.tv/xry_tv' },
                 { name: 'Splitsecond', url: 'https://www.twitch.tv/splitsecondta' },
                 { name: 'Howsya', url: 'https://www.twitch.tv/howsya' }
-            ],
-            'DeadStop': [
-                { name: 'iinferno', url: 'https://www.twitch.tv/bschrift/video/2399902418' },
-                { name: 'Paprika (YT)', url: 'https://www.youtube.com/@0Luna_' },
-                { name: 'Blitz', url: 'https://www.twitch.tv/slohp0k3' }
             ],
             'UE': [
                 { name: 'PabloSexcrobar', url: 'https://www.twitch.tv/eltimablo' },


### PR DESCRIPTION
## Summary
- Remove DeadStop and Viva la Revolución from the dashboard team listings
- Clean up corresponding roster and stream entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3fbccabc832ab7ad0ece0aeba87f