### PR TITLE
Auto-generate playoff schedule and bracket

### DIFF
--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -552,6 +552,26 @@
     });
   }
 
+  function determinePlayoffTeams(schedule, numTeams) {
+    return computeStandings(schedule)
+      .slice(0, numTeams)
+      .map(r => r.team);
+  }
+
+  function generatePlayoffWeeks(playoffTeams, startWeek) {
+    const matches = [];
+    for (let i = 0; i < Math.floor(playoffTeams.length / 2); i++) {
+      matches.push({
+        date: '',
+        away: playoffTeams[playoffTeams.length - 1 - i],
+        home: playoffTeams[i],
+        awayScore: null,
+        homeScore: null
+      });
+    }
+    return [{ week: startWeek, phase: 'playoffs', matches }];
+  }
+
   function renderStandings(rows) {
     const tableEl = document.getElementById('standingsTable');
     tableEl.innerHTML = '';
@@ -609,11 +629,15 @@
   });
 
   document.getElementById('saveSchedule').addEventListener('click', async () => {
-    const schedule = gatherSchedule();
+    let schedule = gatherSchedule().filter(w => (w.phase || 'regular') === 'regular');
+    const playoffTeams = determinePlayoffTeams(schedule, 4);
+    const playoffWeeks = generatePlayoffWeeks(playoffTeams, schedule.length + 1);
+    schedule = [...schedule, ...playoffWeeks];
     const season = currentSeasonData.season;
     const division = document.getElementById('lmDivision').value;
     const docRef = doc(db, 'leagueSchedules', `${season}-${division}`);
     await setDoc(docRef, { season, division, weeks: schedule });
+    renderWeeks(schedule);
     renderStandings(computeStandings(schedule));
   });
 

--- a/StandingsAndMatches.html
+++ b/StandingsAndMatches.html
@@ -118,18 +118,24 @@
       const allTeams = new Set(teamNames);
       weeks.forEach(w => w.matches.forEach(m => { allTeams.add(m.home); allTeams.add(m.away); }));
 
-      const standings = computeStandings(weeks, Array.from(allTeams));
-      renderStandings(standings);
+      const teams = Array.from(allTeams);
+      const standings = computeStandings(weeks, teams);
+      const playoffTeams = determinePlayoffTeams(weeks, 4, teams);
+      renderStandings(standings, playoffTeams);
       renderSchedule(weeks);
     }
 
     function computeStandings(weeks, teams) {
       const table = {};
-      teams.forEach(t => (table[t] = { team: t, wins: 0, losses: 0 }));
+      teams.forEach(t => (table[t] = { team: t, wins: 0, losses: 0, pointsFor: 0, pointsAgainst: 0 }));
       weeks.forEach(w => {
         if (w.phase && w.phase !== 'regular') return;
         w.matches.forEach(m => {
           if (m.homeScore != null && m.awayScore != null) {
+            table[m.home].pointsFor += m.homeScore;
+            table[m.home].pointsAgainst += m.awayScore;
+            table[m.away].pointsFor += m.awayScore;
+            table[m.away].pointsAgainst += m.homeScore;
             if (m.homeScore > m.awayScore) {
               table[m.home].wins++;
               table[m.away].losses++;
@@ -140,18 +146,34 @@
           }
         });
       });
-      return Object.values(table);
+      return Object.values(table).map(r => {
+        const games = r.wins + r.losses;
+        const winPct = games ? r.wins / games : 0;
+        const pointDiff = r.pointsFor - r.pointsAgainst;
+        return { ...r, winPct, pointDiff };
+      }).sort((a, b) => {
+        if (b.winPct !== a.winPct) return b.winPct - a.winPct;
+        if (b.pointDiff !== a.pointDiff) return b.pointDiff - a.pointDiff;
+        return a.team.localeCompare(b.team);
+      });
     }
 
-    function renderStandings(rows) {
+    function determinePlayoffTeams(weeks, numTeams, teams) {
+      return computeStandings(weeks, teams)
+        .slice(0, numTeams)
+        .map(r => r.team);
+    }
+
+    function renderStandings(rows, playoffTeams = []) {
       const table = document.getElementById('standingsTable');
       table.innerHTML = '';
       const header = document.createElement('tr');
-      header.innerHTML = '<th class="px-2">Team</th><th class="px-2">W</th><th class="px-2">L</th>';
+      header.innerHTML = '<th class="px-2">Team</th><th class="px-2">W</th><th class="px-2">L</th><th class="px-2">Win%</th><th class="px-2">+/-</th>';
       table.appendChild(header);
       rows.forEach(r => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td class="px-2">${r.team}</td><td class="px-2">${r.wins}</td><td class="px-2">${r.losses}</td>`;
+        if (playoffTeams.includes(r.team)) tr.classList.add('bg-green-800');
+        tr.innerHTML = `<td class="px-2">${r.team}</td><td class="px-2">${r.wins}</td><td class="px-2">${r.losses}</td><td class="px-2">${r.winPct.toFixed(3)}</td><td class="px-2">${r.pointDiff}</td>`;
         table.appendChild(tr);
       });
     }
@@ -159,6 +181,26 @@
     function renderSchedule(weeks) {
       const container = document.getElementById('scheduleContainer');
       container.innerHTML = '';
+      const playoffWeeks = weeks.filter(w => w.phase === 'playoffs');
+      if (playoffWeeks.length) {
+        const bracket = document.createElement('div');
+        bracket.className = 'mb-6';
+        const heading = document.createElement('h3');
+        heading.className = 'text-lg font-semibold mb-2';
+        heading.textContent = 'Playoff Bracket';
+        bracket.appendChild(heading);
+        const grid = document.createElement('div');
+        grid.className = 'grid grid-cols-2 gap-4';
+        playoffWeeks[0].matches.forEach(m => {
+          const match = document.createElement('div');
+          match.className = 'flex justify-between';
+          match.innerHTML = `<span>${m.away}</span><span>${m.home}</span>`;
+          grid.appendChild(match);
+        });
+        bracket.appendChild(grid);
+        container.appendChild(bracket);
+      }
+
       let currentPhase = 'regular';
       weeks.forEach(w => {
         const phase = w.phase || 'regular';


### PR DESCRIPTION
## Summary
- compute top seeds with `determinePlayoffTeams` and create bracket weeks automatically when saving a season
- highlight qualified teams and show a simple playoff bracket on Standings and Matches view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bcbeba054832a98fb05a959d07f64