### PR TITLE
Restrict admin pages to approved UIDs

### DIFF
--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -115,6 +115,10 @@
   const app = initializeApp(firebaseConfig);
   const db = getFirestore(app);
   const auth = getAuth();
+  const ADMIN_UIDS = [
+    'uid1',
+    'uid2'
+  ];
 
   let seasonsIndex = [];
   let currentSeasonData = null;
@@ -217,7 +221,7 @@
   logoutBtn.addEventListener('click', () => signOut(auth));
 
   onAuthStateChanged(auth, user => {
-    if (user) {
+    if (user && ADMIN_UIDS.includes(user.uid)) {
       loginDiv.classList.add('hidden');
       adminPanel.classList.remove('hidden');
       loadSeasons();
@@ -225,6 +229,10 @@
     } else {
       adminPanel.classList.add('hidden');
       loginDiv.classList.remove('hidden');
+      if (user) {
+        alert('Access denied.');
+        signOut(auth);
+      }
     }
   });
 

--- a/NewsAdmin.html
+++ b/NewsAdmin.html
@@ -58,6 +58,10 @@
     const app = initializeApp(firebaseConfig);
     const db = getFirestore(app);
     const auth = getAuth();
+    const ADMIN_UIDS = [
+      'uid1',
+      'uid2'
+    ];
 
     const loginDiv = document.getElementById('loginDiv');
     const adminPanel = document.getElementById('adminPanel');
@@ -73,13 +77,17 @@
     logoutBtn.addEventListener('click', () => signOut(auth));
 
     onAuthStateChanged(auth, user => {
-      if (user) {
+      if (user && ADMIN_UIDS.includes(user.uid)) {
         loginDiv.classList.add('hidden');
         adminPanel.classList.remove('hidden');
         loadNews();
       } else {
         loginDiv.classList.remove('hidden');
         adminPanel.classList.add('hidden');
+        if (user) {
+          alert('Access denied.');
+          signOut(auth);
+        }
       }
     });
 

--- a/StreamersAdmin.html
+++ b/StreamersAdmin.html
@@ -63,6 +63,10 @@
     const app = initializeApp(firebaseConfig);
     const db = getFirestore(app);
     const auth = getAuth();
+    const ADMIN_UIDS = [
+      'uid1',
+      'uid2'
+    ];
 
     const loginDiv = document.getElementById('loginDiv');
     const adminPanel = document.getElementById('adminPanel');
@@ -78,13 +82,17 @@
     logoutBtn.addEventListener('click', () => signOut(auth));
 
     onAuthStateChanged(auth, user => {
-      if (user) {
+      if (user && ADMIN_UIDS.includes(user.uid)) {
         loginDiv.classList.add('hidden');
         adminPanel.classList.remove('hidden');
         loadStreamers();
       } else {
         loginDiv.classList.remove('hidden');
         adminPanel.classList.add('hidden');
+        if (user) {
+          alert('Access denied.');
+          signOut(auth);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- Secure admin pages by adding lists of approved Firebase user IDs.
- Render admin UI only for authorized users; others are signed out with an error message.

## Testing
- `node - <<'NODE'
const ADMIN_UIDS=['uid1','uid2'];
function signOut(){console.log('signOut called');}
function alert(msg){console.log('alert',msg);}
function loadStreamers(){console.log('loadStreamers called');}
let loginHidden=false; let adminHidden=true;
const user={uid:'unknown'};
if (user && ADMIN_UIDS.includes(user.uid)){
  loginHidden=true; adminHidden=false; loadStreamers();
} else {
  loginHidden=false; adminHidden=true;
  if (user){ alert('Access denied.'); signOut(); }
}
console.log('loginHidden',loginHidden,'adminHidden',adminHidden);
NODE`
- `node - <<'NODE'
const ADMIN_UIDS=['uid1','uid2'];
function signOut(){console.log('signOut called');}
function alert(msg){console.log('alert',msg);}
function loadNews(){console.log('loadNews called');}
let loginHidden=false; let adminHidden=true;
const user={uid:'unauth'};
if (user && ADMIN_UIDS.includes(user.uid)){
  loginHidden=true; adminHidden=false; loadNews();
} else {
  loginHidden=false; adminHidden=true;
  if (user){ alert('Access denied.'); signOut(); }
}
console.log('loginHidden',loginHidden,'adminHidden',adminHidden);
NODE`
- `node - <<'NODE'
const ADMIN_UIDS=['uid1','uid2'];
function signOut(){console.log('signOut called');}
function alert(msg){console.log('alert',msg);}
function loadSeasons(){console.log('loadSeasons called');}
function loadTeams(){console.log('loadTeams called');}
let loginHidden=false; let adminHidden=true;
const user={uid:'bad'};
if (user && ADMIN_UIDS.includes(user.uid)){
  loginHidden=true; adminHidden=false; loadSeasons(); loadTeams();
} else {
  adminHidden=true; loginHidden=false; if (user){ alert('Access denied.'); signOut(); }
}
console.log('loginHidden',loginHidden,'adminHidden',adminHidden);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_689cb70803bc832a978bd9bd0c9fff26