### PR TITLE
Restrict admin access by UID

### DIFF
--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
-  <div id="nav-placeholder" data-include="/nav.html"></div>
+  <div id="nav-placeholder" data-include="nav.html"></div>
 
 
   <div id="loginDiv" class="max-w-sm mx-auto mt-10 space-y-4">
@@ -116,8 +116,8 @@
   const db = getFirestore(app);
   const auth = getAuth();
   const ADMIN_UIDS = [
-    'uid1',
-    'uid2'
+    'DkBHsCzLK5a9KiX50g0pHJrEqGq2',
+    'Cx5w8y1ySNaKFAbHmm2uw1ZPoDr1'
   ];
 
   let seasonsIndex = [];
@@ -673,29 +673,6 @@
     await loadSeasons();
   });
 </script>
-  <script>
-    async function loadNav() {
-      const placeholder = document.getElementById('nav-placeholder');
-      try {
-        const res = await fetch('./nav.html');
-        if (!res.ok) throw new Error(`Nav fetch failed: ${res.status}`);
-        const html = await res.text();
-        placeholder.innerHTML = html;
-        placeholder.querySelectorAll('script').forEach(oldScript => {
-          const newScript = document.createElement('script');
-          [...oldScript.attributes].forEach(attr => newScript.setAttribute(attr.name, attr.value));
-          newScript.textContent = oldScript.textContent;
-          oldScript.replaceWith(newScript);
-        });
-        if (window.twitchOAuth) {
-          window.twitchOAuth.updateNav();
-          window.twitchOAuth.initLiveTeamsMenu();
-        }
-      } catch (err) {
-        console.error('Failed to load navigation', err);
-      }
-    }
-    loadNav();
-  </script>
+  <script src="assets/include.js" defer></script>
 </body>
 </html>

--- a/NewsAdmin.html
+++ b/NewsAdmin.html
@@ -59,8 +59,8 @@
     const db = getFirestore(app);
     const auth = getAuth();
     const ADMIN_UIDS = [
-      'uid1',
-      'uid2'
+      'DkBHsCzLK5a9KiX50g0pHJrEqGq2',
+      'Cx5w8y1ySNaKFAbHmm2uw1ZPoDr1'
     ];
 
     const loginDiv = document.getElementById('loginDiv');

--- a/StreamersAdmin.html
+++ b/StreamersAdmin.html
@@ -64,8 +64,8 @@
     const db = getFirestore(app);
     const auth = getAuth();
     const ADMIN_UIDS = [
-      'uid1',
-      'uid2'
+      'DkBHsCzLK5a9KiX50g0pHJrEqGq2',
+      'Cx5w8y1ySNaKFAbHmm2uw1ZPoDr1'
     ];
 
     const loginDiv = document.getElementById('loginDiv');

--- a/assets/include.js
+++ b/assets/include.js
@@ -1,0 +1,26 @@
+// Simple HTML include loader
+// Replaces elements with a data-include attribute with the referenced HTML
+// and executes any scripts within the included fragment.
+document.addEventListener('DOMContentLoaded', () => {
+  const includeElements = document.querySelectorAll('[data-include]');
+  includeElements.forEach(async el => {
+    const file = el.getAttribute('data-include');
+    if (!file) return;
+    try {
+      const res = await fetch(file);
+      if (!res.ok) throw new Error(`Failed to fetch ${file}`);
+      const html = await res.text();
+      el.innerHTML = html;
+      el.removeAttribute('data-include');
+      // Execute scripts from the included fragment
+      el.querySelectorAll('script').forEach(oldScript => {
+        const script = document.createElement('script');
+        Array.from(oldScript.attributes).forEach(attr => script.setAttribute(attr.name, attr.value));
+        script.appendChild(document.createTextNode(oldScript.innerHTML));
+        oldScript.parentNode.replaceChild(script, oldScript);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  });
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,19 +1,24 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isAdmin() {
+      return request.auth != null &&
+        request.auth.uid in ['DkBHsCzLK5a9KiX50g0pHJrEqGq2', 'Cx5w8y1ySNaKFAbHmm2uw1ZPoDr1'];
+    }
+
     match /streamers/{streamerId} {
-      allow read: if resource.data.approved == true;
+      allow read: if resource.data.approved == true || isAdmin();
       allow create: if request.resource.data.approved == false
         && request.resource.data.displayName is string
         && request.resource.data.twitchHandle is string
         && (!('team' in request.resource.data) || request.resource.data.team is string)
         && (!('bio' in request.resource.data) || request.resource.data.bio is string)
         && (!('avatarUrl' in request.resource.data) || request.resource.data.avatarUrl is string);
-      allow update, delete: if request.auth.uid in ['DkBHsCzLK5a9KiX50g0pHJrEqGq2', 'Cx5w8y1ySNaKFAbHmm2uw1ZPoDr1'];
+      allow update, delete: if isAdmin();
     }
 
     match /teams/{teamId} {
-      allow read: if resource.data.approved == true || request.auth != null;
+      allow read: if resource.data.approved == true || isAdmin();
       allow create: if
         request.resource.data.approved == false &&
         request.resource.data.teamName is string &&
@@ -21,7 +26,22 @@ service cloud.firestore {
         request.resource.data.season is int &&
         request.resource.data.division is string &&
         request.resource.data.division in ['TPL-O', 'TPL-IM', 'TPL-I'];
-      allow update, delete: if request.auth.uid in ['DkBHsCzLK5a9KiX50g0pHJrEqGq2', 'Cx5w8y1ySNaKFAbHmm2uw1ZPoDr1'];
+      allow update, delete: if isAdmin();
+    }
+
+    match /news/{newsId} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+
+    match /leagueSeasons/{seasonId} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+
+    match /leagueSchedules/{docId} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
     }
   }
 }


### PR DESCRIPTION
## Summary
- limit admin pages to known Firebase UIDs, including LeagueManager
- enforce same allow list in Firestore rules for streamers, teams, news, league seasons and schedules
- add include.js loader to fetch shared HTML snippets, resolving missing script errors
- fix League Manager nav by using relative include paths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cb618290c832a967be50f9888a64c