### PR TITLE
Remove redundant submit button click handler

### DIFF
--- a/TeamSignUp.html
+++ b/TeamSignUp.html
@@ -185,7 +185,6 @@
     }
 
     form.addEventListener("submit", submitTeam);
-    submitTeamBtn.addEventListener("click", submitTeam);
 
     loadTeams();
 


### PR DESCRIPTION
## Summary
- Eliminate duplicate `submitTeam` handler by removing explicit click listener on the submit button
- Rely solely on the form's submit event for team submissions

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a75f145688832aac20fd3ccbe002ab