### PR TITLE
Show error details on team submission failure

### DIFF
--- a/TeamSignUp.html
+++ b/TeamSignUp.html
@@ -180,7 +180,7 @@
         loadTeams();
       } catch (err) {
         console.error('Failed to add team', err);
-        status.textContent = 'Failed to submit team.';
+        status.textContent = `Failed to submit team: ${err.message}`;
       }
     }
 


### PR DESCRIPTION
## Summary
- Display underlying error message when team submission fails so users know the cause

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a75f151d90832a9e7d30906415ec50