### PR TITLE
refactor: centralize Twitch client ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,6 +316,7 @@
 
     <script>
         var rosters = {};
+        const CLIENT_ID = 'meabi1n42pccff5rz9ujpno7ky9vlt';
 
         const streams = {
             'Avalanche': [
@@ -426,7 +427,7 @@
 
             const query = allLogins.map(l => 'user_login=' + encodeURIComponent(l)).join('&');
             fetch('https://api.twitch.tv/helix/streams?' + query, {
-                headers: { 'Client-Id': 'meabi1n42pccff5rz9ujpno7ky9vlt' }
+                headers: { 'Client-Id': CLIENT_ID }
             })
                 .then(res => res.json())
                 .then(data => {
@@ -447,7 +448,7 @@
         function updateHubcasterStatus() {
             const query = hubCasters.map(l => 'user_login=' + encodeURIComponent(l)).join('&');
             fetch('https://api.twitch.tv/helix/streams?' + query, {
-                headers: { 'Client-Id': 'meabi1n42pccff5rz9ujpno7ky9vlt' }
+                headers: { 'Client-Id': CLIENT_ID }
             })
                 .then(res => res.json())
                 .then(data => {

--- a/oauth.js
+++ b/oauth.js
@@ -1,4 +1,5 @@
 (function(){
+  // Twitch application client ID
   const CLIENT_ID = 'meabi1n42pccff5rz9ujpno7ky9vlt';
   // Always return to the new TPL dashboard after Twitch auth.
   // Build the redirect path relative to the current directory so GitHub Pages


### PR DESCRIPTION
## Summary
- centralize Twitch API client ID in `index.html`
- document Twitch client ID in `oauth.js`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa30cc19b4832a84a177a9677ba5f3