### PR TITLE
Update admin UID references

### DIFF
--- a/NewsAdmin.html
+++ b/NewsAdmin.html
@@ -60,7 +60,7 @@
     const auth = getAuth();
     const ADMIN_UIDS = [
       'DkBHsCzLK5a9KiX50g0pHJrEqGq2',
-      'Cx5w8y1ySNaKFAbHmm2uw1ZPoDr1'
+      'A2ZV8vziNsXqZkyqHzAB266B9pP2'
     ];
 
     const loginDiv = document.getElementById('loginDiv');

--- a/StreamersAdmin.html
+++ b/StreamersAdmin.html
@@ -65,7 +65,7 @@
     const auth = getAuth();
     const ADMIN_UIDS = [
       'DkBHsCzLK5a9KiX50g0pHJrEqGq2',
-      'Cx5w8y1ySNaKFAbHmm2uw1ZPoDr1'
+      'A2ZV8vziNsXqZkyqHzAB266B9pP2'
     ];
 
     const loginDiv = document.getElementById('loginDiv');

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,7 +3,7 @@ service cloud.firestore {
   match /databases/{database}/documents {
     function isAdmin() {
       return request.auth != null &&
-        request.auth.uid in ['DkBHsCzLK5a9KiX50g0pHJrEqGq2', 'Cx5w8y1ySNaKFAbHmm2uw1ZPoDr1'];
+        request.auth.uid in ['DkBHsCzLK5a9KiX50g0pHJrEqGq2', 'A2ZV8vziNsXqZkyqHzAB266B9pP2'];
     }
 
     match /streamers/{streamerId} {


### PR DESCRIPTION
## Summary
- replace deprecated admin UID with new A2ZV8vziNsXqZkyqHzAB266B9pP2 in NewsAdmin and StreamersAdmin
- update Firestore rules to include new admin UID

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1e7c3498832a98301a6ba5fea2a1