### PR TITLE
Refresh Twitch OAuth nav after includes

### DIFF
--- a/assets/include.js
+++ b/assets/include.js
@@ -19,6 +19,11 @@ document.addEventListener('DOMContentLoaded', () => {
         script.appendChild(document.createTextNode(oldScript.innerHTML));
         oldScript.parentNode.replaceChild(script, oldScript);
       });
+      // Update Twitch OAuth navigation state and live teams menu if available
+      if (window.twitchOAuth) {
+        window.twitchOAuth.updateNav();
+        window.twitchOAuth.initLiveTeamsMenu();
+      }
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Summary
- ensure Twitch OAuth navigation state and team menu refresh after injecting included HTML

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bb5d6268c0832a95a737322983e9bf