### PR TITLE
Update team dropdown links to external sites

### DIFF
--- a/nav.html
+++ b/nav.html
@@ -24,20 +24,20 @@
           <div class="invisible opacity-0 group-hover:visible group-hover:opacity-100 transition-all duration-150 absolute mt-2 min-w-48 rounded-xl border border-gray-800 bg-gray-900 shadow-xl p-2 z-50">
             <a href="TPLTeamsDashboard.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
             <div class="my-2 h-px bg-gray-800"></div>
-            <a href="TeamAV.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
-            <a href="TeamDS.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
-            <a href="TeamDPRK.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">[DPRK] Team</a>
-            <a href="TeamEPI.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
-            <a href="TeamFPS.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
-            <a href="TeamFT.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
-            <a href="TeamHoE.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
-            <a href="TeamKTL.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
-            <a href="TeamMagic.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
-            <a href="TeamNull.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">null [null]</a>
-            <a href="TeamTXM.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
-            <a href="TeamToxicAimers.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
-            <a href="TeamUE.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
-            <a href="TeamZen.html" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
+            <a href="https://www.team-avalanche.online/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
+            <a href="https://t24085.github.io/Team-DeadStop/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
+            <a href="https://t24085.github.io/TeamDPRK/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">[DPRK] Team</a>
+            <a href="https://t24085.github.io/Team-ePi/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
+            <a href="https://t24085.github.io/Team-FPS/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
+            <a href="https://t24085.github.io/Team-FT/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
+            <a href="https://t24085.github.io/Team-HOE/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
+            <a href="https://t24085.github.io/Team-KTL/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
+            <a href="https://t24085.github.io/Team-Magic/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
+            <a href="https://t24085.github.io/Team-Null/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">null [null]</a>
+            <a href="https://t24085.github.io/Team-TXM/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
+            <a href="https://t24085.github.io/Team-Toxic-Aimers/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
+            <a href="https://t24085.github.io/Team-UE/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
+            <a href="https://t24085.github.io/Team-Zen/" class="nav-link block px-3 py-2 rounded-lg text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
           </div>
         </div>
         <a href="StandingsAndMatches.html" class="nav-link text-gray-200 hover:text-white">Schedule</a>
@@ -112,20 +112,20 @@
         </summary>
         <div class="mt-1 pl-3 space-y-1">
           <a href="TPLTeamsDashboard.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Teams Dashboard</a>
-          <a href="TeamAV.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
-          <a href="TeamDS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
-          <a href="TeamDPRK.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">[DPRK] Team</a>
-          <a href="TeamEPI.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
-          <a href="TeamFPS.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
-          <a href="TeamFT.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
-          <a href="TeamHoE.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
-          <a href="TeamKTL.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
-          <a href="TeamMagic.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
-          <a href="TeamNull.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">null [null]</a>
-          <a href="TeamTXM.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
-          <a href="TeamToxicAimers.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
-          <a href="TeamUE.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
-          <a href="TeamZen.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
+          <a href="https://www.team-avalanche.online/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Avalanche [aV!]</a>
+          <a href="https://t24085.github.io/Team-DeadStop/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">DeadStop [DS]</a>
+          <a href="https://t24085.github.io/TeamDPRK/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">[DPRK] Team</a>
+          <a href="https://t24085.github.io/Team-ePi/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">ePidemic [ePi]</a>
+          <a href="https://t24085.github.io/Team-FPS/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flag Pole Smokers [FPS]</a>
+          <a href="https://t24085.github.io/Team-FT/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Flying Tractors [^T^]</a>
+          <a href="https://t24085.github.io/Team-HOE/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Hegemony of Euros [HoE]</a>
+          <a href="https://t24085.github.io/Team-KTL/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">KTL [KTL]</a>
+          <a href="https://t24085.github.io/Team-Magic/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Magic [Wiz]</a>
+          <a href="https://t24085.github.io/Team-Null/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">null [null]</a>
+          <a href="https://t24085.github.io/Team-TXM/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Texas Militia [TXM]</a>
+          <a href="https://t24085.github.io/Team-Toxic-Aimers/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Toxic Aimers</a>
+          <a href="https://t24085.github.io/Team-UE/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Unhandled Exception [UE]</a>
+          <a href="https://t24085.github.io/Team-Zen/" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Zen [ℨ]</a>
         </div>
       </details>
       <a href="StandingsAndMatches.html" class="block rounded-lg px-3 py-2 text-gray-200 hover:bg-gray-800">Schedule</a>


### PR DESCRIPTION
## Summary
- Point Teams dropdown links in `nav.html` to each team's external website.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5d6370e8832a9d5681938237c2a3