### PR TITLE
Fix Raindance map duplication on Match Stats Admin

### DIFF
--- a/MatchStatsAdmin.html
+++ b/MatchStatsAdmin.html
@@ -112,7 +112,7 @@
       }
     });
 
-    const mapList = ['Dry Dock','Rain','Dance','Hollow','Dangerous Crossing','Torment','Katabatic','Wave Mist','Moonrise'];
+    const mapList = ['Dry Dock','Raindance','Hollow','Dangerous Crossing','Torment','Katabatic','Wave Mist','Moonrise'];
     const mapSelect = document.getElementById('map');
     mapList.forEach(m => {
       const opt = document.createElement('option');


### PR DESCRIPTION
## Summary
- correct the map list so Raindance appears as a single option in the Match Stats Admin page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc86592a58832a8714fc28058e0cf3