### PR TITLE
Fix navbar includes to work from subpaths

### DIFF
--- a/DraftSignUp.html
+++ b/DraftSignUp.html
@@ -73,7 +73,7 @@
   </style>
 </head>
 <body class="text-white">
-    <div id="nav-placeholder" data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="nav.html"></div>
   <div id="root"></div>
   <script type="text/babel">
     const POSITIONS = ['HoF', 'LD', 'MD', 'MO', 'HO', 'LO', 'Capper'];

--- a/LeagueManager.html
+++ b/LeagueManager.html
@@ -633,7 +633,7 @@
     await loadSeasons();
   });
 </script>
-  <script src="assets/include.js" defer></script>
+  <script src="./assets/include.js" defer></script>
 
 </body>
 </html>

--- a/MatchStatsAdmin.html
+++ b/MatchStatsAdmin.html
@@ -8,7 +8,7 @@
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-  <div id="nav-placeholder" data-include="/nav.html"></div>
+  <div id="nav-placeholder" data-include="nav.html"></div>
 
   <div id="loginDiv" class="max-w-sm mx-auto mt-10 space-y-4">
     <h1 class="text-2xl font-bold text-center">Admin Login</h1>
@@ -401,6 +401,6 @@
       XLSX.writeFile(wb, 'match-stats.xlsx');
     });
   </script>
-  <script src="/assets/include.js" defer></script>
+  <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/News.html
+++ b/News.html
@@ -8,14 +8,14 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-  <div id="nav-placeholder" data-include="/nav.html"></div>
+  <div id="nav-placeholder" data-include="nav.html"></div>
 
   <main class="container mx-auto px-4 py-8">
     <h1 class="text-3xl font-bold mb-6">News</h1>
     <ul id="newsList" class="space-y-6"></ul>
   </main>
 
-  <script src="/assets/include.js" defer></script>
+  <script src="./assets/include.js" defer></script>
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
     import { getFirestore, collection, getDocs, orderBy, query } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";

--- a/NewsAdmin.html
+++ b/NewsAdmin.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-  <div id="nav-placeholder" data-include="/nav.html"></div>
+  <div id="nav-placeholder" data-include="nav.html"></div>
 
   <div id="loginDiv" class="max-w-sm mx-auto mt-10 space-y-4">
     <h1 class="text-2xl font-bold text-center">Admin Login</h1>
@@ -150,6 +150,6 @@
       }));
     }
   </script>
-  <script src="/assets/include.js" defer></script>
+  <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/Schedule.html
+++ b/Schedule.html
@@ -6,8 +6,8 @@
   <title>Schedule</title>
 </head>
 <body class="bg-gray-900 text-white">
-  <div data-include="/nav.html"></div>
+  <div data-include="nav.html"></div>
   <p class="p-4">Redirecting to <a href="StandingsAndMatches.html">Standings and Matches</a>...</p>
-  <script src="/assets/include.js" defer></script>
+  <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/Standings.html
+++ b/Standings.html
@@ -6,8 +6,8 @@
   <title>Standings</title>
 </head>
 <body class="bg-gray-900 text-white">
-  <div data-include="/nav.html"></div>
+  <div data-include="nav.html"></div>
   <p class="p-4">Redirecting to <a href="StandingsAndMatches.html">Standings and Matches</a>...</p>
-  <script src="/assets/include.js" defer></script>
+  <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/StandingsAndMatches.html
+++ b/StandingsAndMatches.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
-    <div id="nav-placeholder" data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="nav.html"></div>
 
   <div class="w-full max-w-6xl p-4">
     <h1 class="text-2xl font-bold text-center mb-4">TPL Standings and Matches</h1>

--- a/StreamerKits.html
+++ b/StreamerKits.html
@@ -8,7 +8,7 @@
 </head>
 <body class="bg-gradient-to-b from-gray-900 via-gray-800 to-gray-900 text-white min-h-screen">
   <!-- Nav include -->
-  <div id="nav-placeholder" data-include="/nav.html"></div>
+  <div id="nav-placeholder" data-include="nav.html"></div>
 
   <!-- Header -->
   <header class="relative z-10 text-center py-10">
@@ -287,6 +287,6 @@
     <p>© 2025 Tribes League | Streamer Kits Showcase</p>
   </footer>
 
-  <script src="/assets/include.js" defer></script>
+  <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/Streamers.html
+++ b/Streamers.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-    <div id="nav-placeholder" data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="nav.html"></div>
 
   <div class="container mx-auto px-4 mt-8">
     <h1 class="text-3xl font-bold text-center mb-6">Tribes Streamers</h1>
@@ -20,7 +20,7 @@
   <div id="streamersGrid" class="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"></div>
   </div>
 
-  <script src="/assets/include.js" defer></script>
+  <script src="./assets/include.js" defer></script>
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
     import { getFirestore, collection, getDocs, query, where } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";

--- a/StreamersAdmin.html
+++ b/StreamersAdmin.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-    <div id="nav-placeholder" data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="nav.html"></div>
 
   <div id="loginDiv" class="max-w-sm mx-auto mt-10 space-y-4">
     <h1 class="text-2xl font-bold text-center">Admin Login</h1>
@@ -142,6 +142,6 @@
     }
 
   </script>
-    <script src="/assets/include.js" defer></script>
+    <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/StreamersSubmit.html
+++ b/StreamersSubmit.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
-    <div data-include="/nav.html"></div>
+    <div data-include="nav.html"></div>
 
   <div class="max-w-md mx-auto mt-10 p-6 bg-gray-800 rounded-lg shadow">
     <h1 class="text-2xl font-bold text-center mb-4">Submit a Streamer</h1>
@@ -62,6 +62,6 @@
       document.getElementById('status').classList.remove('hidden');
     });
   </script>
-    <script src="/assets/include.js" defer></script>
+    <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/TeamSignUp.html
+++ b/TeamSignUp.html
@@ -7,7 +7,7 @@
   <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center">
-    <div id="nav-placeholder" data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="nav.html"></div>
 
 
   <div class="bg-gray-800 shadow-lg rounded-2xl p-8 w-full max-w-2xl mt-8">

--- a/TournamentBrackets.html
+++ b/TournamentBrackets.html
@@ -82,7 +82,7 @@
   </style>
 </head>
 <body class="text-white">
-    <div data-include="/nav.html"></div>
+    <div data-include="nav.html"></div>
   <div id="root"></div>
   <script type="text/babel">
     const Match = ({ match, roundIndex, matchIndex, onSubmitScores, tournamentStyle, matchHeight, positionTop, nextMatchPosition, prevMatchPositions }) => {
@@ -1646,6 +1646,6 @@
     const root = ReactDOM.createRoot(document.getElementById('root'));
     root.render(<App />);
   </script>
-    <script src="/assets/include.js" defer></script>
+    <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/TournamentManager.html
+++ b/TournamentManager.html
@@ -32,7 +32,7 @@
   </style>
 </head>
 <body class="text-white">
-    <div data-include="/nav.html"></div>
+    <div data-include="nav.html"></div>
   <div id="root"></div>
   <script type="text/babel">
     const POSITIONS = ['HoF', 'LD', 'MD', 'MO', 'HO', 'LO', 'Capper'];
@@ -428,6 +428,6 @@
     const root = ReactDOM.createRoot(document.getElementById('root'));
     root.render(<App />);
   </script>
-    <script src="/assets/include.js" defer></script>
+    <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/TribesScrimWatcher.html
+++ b/TribesScrimWatcher.html
@@ -116,7 +116,7 @@
     </style>
 </head>
 <body class="font-sans">
-    <div id="nav-placeholder" data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="nav.html"></div>
     <header class="text-center py-6">
         <h1 class="text-4xl font-bold text-violet-400">Tribes Professional League Scrim Watcher</h1>
     </header>

--- a/TwinsTournamentDataCenter.html
+++ b/TwinsTournamentDataCenter.html
@@ -86,7 +86,7 @@
     </style>
 </head>
 <body class="text-white min-h-screen">
-    <div data-include="/nav.html"></div>
+    <div data-include="nav.html"></div>
     <div id="root"></div>
 
     <script type="text/babel">
@@ -195,7 +195,7 @@
         const root = ReactDOM.createRoot(document.getElementById('root'));
         root.render(<Dashboard />);
     </script>
-    <script src="/assets/include.js" defer></script>
+    <script src="./assets/include.js" defer></script>
 </body>
 </html>
 

--- a/TwitchFeedDisplays.html
+++ b/TwitchFeedDisplays.html
@@ -299,7 +299,7 @@
   </style>
 </head>
 <body>
-    <div id="nav-placeholder" data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="nav.html"></div>
   <div class="container">
     <header>
       <div class="form-section">

--- a/TwitchFeedMobile.html
+++ b/TwitchFeedMobile.html
@@ -292,7 +292,7 @@
   </style>
 </head>
 <body>
-    <div data-include="/nav.html"></div>
+    <div data-include="nav.html"></div>
   <nav class="bg-gray-900 bg-opacity-90 backdrop-blur-md shadow-lg sticky top-0 z-50">
     <div class="container mx-auto">
       <ul class="flex flex-wrap justify-center gap-6 py-2 text-lg font-semibold">
@@ -616,6 +616,6 @@
     // Initial render
     renderStreams();
   </script>
-    <script src="/assets/include.js" defer></script>
+    <script src="./assets/include.js" defer></script>
 </body>
 </html>

--- a/UpcomingEvents.html
+++ b/UpcomingEvents.html
@@ -8,7 +8,7 @@
     <script src="oauth.js"></script>
 </head>
 <body class="bg-gray-900 text-white">
-    <div id="nav-placeholder" data-include="/nav.html"></div>
+    <div id="nav-placeholder" data-include="nav.html"></div>
     <main class="container mx-auto p-4">
         <h1 class="text-3xl font-bold mb-4 text-center">Upcoming Events</h1>
         <img src="Twin.jpg" alt="Twins" class="mx-auto mb-4 max-w-xs">

--- a/assets/include.js
+++ b/assets/include.js
@@ -6,8 +6,13 @@ document.addEventListener('DOMContentLoaded', () => {
   includeElements.forEach(async el => {
     const file = el.getAttribute('data-include');
     if (!file) return;
+    const trimmed = file.trim();
+    const isAbsoluteHttp = /^https?:\/\//i.test(trimmed);
+    const normalizedPath = (!isAbsoluteHttp && trimmed.startsWith('/') && !trimmed.startsWith('//'))
+      ? `.${trimmed}`
+      : trimmed;
     try {
-      const res = await fetch(file);
+      const res = await fetch(normalizedPath);
       if (!res.ok) throw new Error(`Failed to fetch ${file}`);
       const html = await res.text();
       el.innerHTML = html;

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 </head>
 <body class="text-white antialiased selection:bg-brand-600/30">
   <!-- Sticky nav placeholder -->
-  <div id="nav-placeholder" data-include="/nav.html"></div>
+  <div id="nav-placeholder" data-include="nav.html"></div>
 
   <!-- Hero -->
   <header class="relative py-14 border-b border-white/10">


### PR DESCRIPTION
## Summary
- normalize the include loader to treat leading-slash fragments as relative so nav.html resolves correctly
- switch every page that uses the shared nav to request `nav.html` and `./assets/include.js`, keeping the navbar available when served from a subpath

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cec67589dc832a8ccbe90972ca2fe5