### PR TITLE
Allow adding sub players on stats admin page

### DIFF
--- a/MatchStatsAdmin.html
+++ b/MatchStatsAdmin.html
@@ -206,8 +206,12 @@
       document.getElementById('team1').value = team1 ? team1.id : '';
       document.getElementById('team2').value = team2 ? team2.id : '';
       document.getElementById('map').value = data.map;
-      createStatsTable('team1Stats', team1);
-      createStatsTable('team2Stats', team2);
+      const team1Stats = data.stats?.[data.team1] || null;
+      const team2Stats = data.stats?.[data.team2] || null;
+      const team1ForTable = team1 || { name: data.team1, players: Object.keys(team1Stats?.players || {}) };
+      const team2ForTable = team2 || { name: data.team2, players: Object.keys(team2Stats?.players || {}) };
+      createStatsTable('team1Stats', team1ForTable, team1Stats);
+      createStatsTable('team2Stats', team2ForTable, team2Stats);
       document.getElementById('statsSection').classList.remove('hidden');
       const inputs = document.querySelectorAll('.stat-input');
       inputs.forEach(inp => {
@@ -237,9 +241,13 @@
       document.getElementById('statsSection').classList.remove('hidden');
     });
 
-    function createStatsTable(containerId, team) {
+    function createStatsTable(containerId, team, existingStats = null) {
       const container = document.getElementById(containerId);
       container.innerHTML = '';
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'space-y-2';
+
       const table = document.createElement('table');
       table.className = 'min-w-full text-left border border-gray-700';
       table.innerHTML = `
@@ -253,25 +261,82 @@
             <th class="px-2">Captures</th>
             <th class="px-2">Returns</th>
             <th class="px-2">Time (min)</th>
+            <th class="px-2">Remove</th>
           </tr>
         </thead>
         <tbody></tbody>
       `;
       const tbody = table.querySelector('tbody');
-      team.players.forEach(p => {
+
+      const rosterPlayers = team.players || [];
+      const existingPlayers = existingStats?.players ? Object.keys(existingStats.players) : [];
+      const playerSet = new Set([...rosterPlayers, ...existingPlayers]);
+
+      const addPlayerRow = (playerName, statValues = {}, isRosterPlayer = false) => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `
-          <td class="px-2">${p}</td>
-          <td><input type="number" class="stat-input w-20 px-1 bg-gray-800 border border-gray-700" data-player="${p}" data-team="${team.name}" data-stat="kills" value="0"></td>
-          <td><input type="number" class="stat-input w-20 px-1 bg-gray-800 border border-gray-700" data-player="${p}" data-team="${team.name}" data-stat="assists" value="0"></td>
-          <td><input type="number" class="stat-input w-20 px-1 bg-gray-800 border border-gray-700" data-player="${p}" data-team="${team.name}" data-stat="score" value="0"></td>
-          <td><input type="number" class="stat-input w-20 px-1 bg-gray-800 border border-gray-700" data-player="${p}" data-team="${team.name}" data-stat="captures" value="0"></td>
-          <td><input type="number" class="stat-input w-20 px-1 bg-gray-800 border border-gray-700" data-player="${p}" data-team="${team.name}" data-stat="returns" value="0"></td>
-          <td><input type="number" class="stat-input w-20 px-1 bg-gray-800 border border-gray-700" data-player="${p}" data-team="${team.name}" data-stat="time" value="0"></td>
-        `;
+        tr.dataset.playerName = playerName;
+
+        const nameTd = document.createElement('td');
+        nameTd.className = 'px-2';
+        nameTd.textContent = playerName;
+        tr.appendChild(nameTd);
+
+        ['kills', 'assists', 'score', 'captures', 'returns', 'time'].forEach(stat => {
+          const td = document.createElement('td');
+          const input = document.createElement('input');
+          input.type = 'number';
+          input.className = 'stat-input w-20 px-1 bg-gray-800 border border-gray-700';
+          input.dataset.player = playerName;
+          input.dataset.team = team.name;
+          input.dataset.stat = stat;
+          input.value = statValues[stat] ?? 0;
+          td.appendChild(input);
+          tr.appendChild(td);
+        });
+
+        const removeTd = document.createElement('td');
+        removeTd.className = 'px-2';
+        if (!isRosterPlayer) {
+          const removeBtn = document.createElement('button');
+          removeBtn.type = 'button';
+          removeBtn.className = 'px-2 py-1 bg-red-600 hover:bg-red-700 rounded';
+          removeBtn.textContent = 'Remove';
+          removeBtn.addEventListener('click', () => {
+            tbody.removeChild(tr);
+            playerSet.delete(playerName);
+          });
+          removeTd.appendChild(removeBtn);
+        }
+        tr.appendChild(removeTd);
+
         tbody.appendChild(tr);
+      };
+
+      playerSet.forEach(p => {
+        addPlayerRow(p, existingStats?.players?.[p] || {}, rosterPlayers.includes(p));
       });
-      container.appendChild(table);
+
+      wrapper.appendChild(table);
+
+      const addSubBtn = document.createElement('button');
+      addSubBtn.type = 'button';
+      addSubBtn.className = 'mt-2 px-3 py-1 bg-purple-600 hover:bg-purple-700 rounded';
+      addSubBtn.textContent = 'Add Sub Player';
+      addSubBtn.addEventListener('click', () => {
+        const name = prompt('Enter sub player name:');
+        if (!name) return;
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        if (playerSet.has(trimmed)) {
+          alert('Player already exists in this team list.');
+          return;
+        }
+        playerSet.add(trimmed);
+        addPlayerRow(trimmed, {}, false);
+      });
+
+      wrapper.appendChild(addSubBtn);
+      container.appendChild(wrapper);
     }
 
     document.getElementById('saveMatch').addEventListener('click', async () => {
@@ -320,7 +385,7 @@
       const saveData = { map, team1: t1.name, team2: t2.name, created: currentMatchCreated || new Date(), stats: {} };
 
       [t1.name, t2.name].forEach(teamName => {
-        const teamStats = stats[teamName];
+        const teamStats = stats[teamName] || {};
         let totals = { kills:0, assists:0, score:0, captures:0, returns:0, time:0 };
         saveData.stats[teamName] = { players: {}, totals:{} };
         Object.keys(teamStats).forEach(player => {


### PR DESCRIPTION
## Summary
- allow match editors to append or remove sub players directly from each team stats table
- ensure saved match edits include existing non-roster players and handle missing rosters gracefully

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daab02f584832aa83b6f6fa21594d2