### PR TITLE
Show running totals automatically in match stats admin

### DIFF
--- a/MatchStatsAdmin.html
+++ b/MatchStatsAdmin.html
@@ -86,6 +86,11 @@
 
     let editingMatchId = null, currentMatchCreated = null;
 
+    const toNumber = (value) => {
+      const num = parseFloat(value);
+      return Number.isFinite(num) ? num : 0;
+    };
+
 
     loginBtn.addEventListener('click', () => {
       const email = document.getElementById('email').value;
@@ -191,8 +196,10 @@
       if (editingMatchId === id) {
         editingMatchId = null;
         currentMatchCreated = null;
-        document.getElementById('statsSection').classList.add('hidden');
+        const statsSection = document.getElementById('statsSection');
+        statsSection.classList.add('hidden');
         document.getElementById('saveMatch').textContent = 'Save Match';
+        resetOutput();
       }
       loadMatches();
     }
@@ -218,11 +225,12 @@
         const player = inp.dataset.player;
         const team = inp.dataset.team;
         const stat = inp.dataset.stat;
-        const teamData = data.stats[team];
+        const teamData = data.stats?.[team];
         if (teamData && teamData.players[player]) {
           inp.value = teamData.players[player][stat] || 0;
         }
       });
+      renderRunningTotals(data.stats || {});
     }
 
     document.getElementById('createMatch').addEventListener('click', () => {
@@ -239,6 +247,7 @@
       createStatsTable('team1Stats', t1);
       createStatsTable('team2Stats', t2);
       document.getElementById('statsSection').classList.remove('hidden');
+      resetOutput();
     });
 
     function createStatsTable(containerId, team, existingStats = null) {
@@ -339,24 +348,68 @@
       container.appendChild(wrapper);
     }
 
-    document.getElementById('saveMatch').addEventListener('click', async () => {
-      const map = document.getElementById('map').value;
-      const t1 = teamsData.find(t => t.id === document.getElementById('team1').value);
-      const t2 = teamsData.find(t => t.id === document.getElementById('team2').value);
+    function resetOutput() {
+      document.getElementById('output').innerHTML = '';
+      document.getElementById('exportBtn').disabled = true;
+    }
+
+    function buildSaveData(map, t1, t2) {
       const inputs = Array.from(document.querySelectorAll('.stat-input'));
       const stats = {};
       inputs.forEach(inp => {
         const player = inp.dataset.player;
         const team = inp.dataset.team;
         const stat = inp.dataset.stat;
-        const val = parseFloat(inp.value) || 0;
+        const val = toNumber(inp.value);
         if (!stats[team]) stats[team] = {};
         if (!stats[team][player]) stats[team][player] = { kills:0, assists:0, score:0, captures:0, returns:0, time:0 };
         stats[team][player][stat] = val;
       });
 
+      const payload = { map, team1: t1.name, team2: t2.name, created: currentMatchCreated || new Date(), stats: {} };
+
+      [t1.name, t2.name].forEach(teamName => {
+        const teamStats = stats[teamName] || {};
+        const totals = { kills:0, assists:0, score:0, captures:0, returns:0, time:0 };
+        const playersPayload = {};
+        Object.keys(teamStats).forEach(player => {
+          const s = teamStats[player];
+          totals.kills += s.kills;
+          totals.assists += s.assists;
+          totals.score += s.score;
+          totals.captures += s.captures;
+          totals.returns += s.returns;
+          totals.time += s.time;
+          const kpm = s.time ? (s.kills / s.time).toFixed(2) : '0';
+          const apm = s.time ? (s.assists / s.time).toFixed(2) : '0';
+          const spm = s.time ? (s.score / s.time).toFixed(2) : '0';
+          const cpm = s.time ? (s.captures / s.time).toFixed(2) : '0';
+          const rpm = s.time ? (s.returns / s.time).toFixed(2) : '0';
+          playersPayload[player] = { ...s, kpm, apm, spm, cpm, rpm };
+        });
+        const teamKpm = totals.time ? (totals.kills / totals.time).toFixed(2) : '0';
+        const teamApm = totals.time ? (totals.assists / totals.time).toFixed(2) : '0';
+        const teamSpm = totals.time ? (totals.score / totals.time).toFixed(2) : '0';
+        const teamCpm = totals.time ? (totals.captures / totals.time).toFixed(2) : '0';
+        const teamRpm = totals.time ? (totals.returns / totals.time).toFixed(2) : '0';
+        payload.stats[teamName] = {
+          players: playersPayload,
+          totals: { ...totals, kpm: teamKpm, apm: teamApm, spm: teamSpm, cpm: teamCpm, rpm: teamRpm }
+        };
+      });
+
+      return payload;
+    }
+
+    function renderRunningTotals(statsByTeam = {}) {
       const output = document.getElementById('output');
       output.innerHTML = '';
+      const teamNames = Object.keys(statsByTeam);
+      if (!teamNames.length) {
+        document.getElementById('exportBtn').disabled = true;
+        return;
+      }
+
       const exportTable = document.createElement('table');
       exportTable.id = 'exportTable';
       exportTable.className = 'min-w-full text-left border border-gray-700';
@@ -382,36 +435,42 @@
       `;
       const tbody = exportTable.querySelector('tbody');
 
-      const saveData = { map, team1: t1.name, team2: t2.name, created: currentMatchCreated || new Date(), stats: {} };
+      teamNames.forEach(teamName => {
+        const teamStats = statsByTeam[teamName] || {};
+        const players = teamStats.players || {};
+        const totals = { kills:0, assists:0, score:0, captures:0, returns:0, time:0 };
 
-      [t1.name, t2.name].forEach(teamName => {
-        const teamStats = stats[teamName] || {};
-        let totals = { kills:0, assists:0, score:0, captures:0, returns:0, time:0 };
-        saveData.stats[teamName] = { players: {}, totals:{} };
-        Object.keys(teamStats).forEach(player => {
-          const s = teamStats[player];
-          totals.kills += s.kills;
-          totals.assists += s.assists;
-          totals.score += s.score;
-          totals.captures += s.captures;
-          totals.returns += s.returns;
-          totals.time += s.time;
-          const kpm = s.time ? (s.kills / s.time).toFixed(2) : '0';
-          const apm = s.time ? (s.assists / s.time).toFixed(2) : '0';
-          const spm = s.time ? (s.score / s.time).toFixed(2) : '0';
-          const cpm = s.time ? (s.captures / s.time).toFixed(2) : '0';
-          const rpm = s.time ? (s.returns / s.time).toFixed(2) : '0';
-          saveData.stats[teamName].players[player] = { ...s, kpm, apm, spm, cpm, rpm };
+        Object.keys(players).forEach(player => {
+          const statEntry = players[player] || {};
+          const kills = toNumber(statEntry.kills);
+          const assists = toNumber(statEntry.assists);
+          const score = toNumber(statEntry.score);
+          const captures = toNumber(statEntry.captures);
+          const returns = toNumber(statEntry.returns);
+          const time = toNumber(statEntry.time);
+          totals.kills += kills;
+          totals.assists += assists;
+          totals.score += score;
+          totals.captures += captures;
+          totals.returns += returns;
+          totals.time += time;
+
+          const kpm = time ? (kills / time).toFixed(2) : (statEntry.kpm ?? '0');
+          const apm = time ? (assists / time).toFixed(2) : (statEntry.apm ?? '0');
+          const spm = time ? (score / time).toFixed(2) : (statEntry.spm ?? '0');
+          const cpm = time ? (captures / time).toFixed(2) : (statEntry.cpm ?? '0');
+          const rpm = time ? (returns / time).toFixed(2) : (statEntry.rpm ?? '0');
+
           const tr = document.createElement('tr');
           tr.innerHTML = `
             <td class="px-2">${teamName}</td>
             <td class="px-2">${player}</td>
-            <td class="px-2">${s.kills}</td>
-            <td class="px-2">${s.assists}</td>
-            <td class="px-2">${s.score}</td>
-            <td class="px-2">${s.captures}</td>
-            <td class="px-2">${s.returns}</td>
-            <td class="px-2">${s.time}</td>
+            <td class="px-2">${kills}</td>
+            <td class="px-2">${assists}</td>
+            <td class="px-2">${score}</td>
+            <td class="px-2">${captures}</td>
+            <td class="px-2">${returns}</td>
+            <td class="px-2">${time}</td>
             <td class="px-2">${kpm}</td>
             <td class="px-2">${apm}</td>
             <td class="px-2">${spm}</td>
@@ -420,23 +479,31 @@
           `;
           tbody.appendChild(tr);
         });
-        const teamKpm = totals.time ? (totals.kills / totals.time).toFixed(2) : '0';
-        const teamApm = totals.time ? (totals.assists / totals.time).toFixed(2) : '0';
-        const teamSpm = totals.time ? (totals.score / totals.time).toFixed(2) : '0';
-        const teamCpm = totals.time ? (totals.captures / totals.time).toFixed(2) : '0';
-        const teamRpm = totals.time ? (totals.returns / totals.time).toFixed(2) : '0';
-        saveData.stats[teamName].totals = { ...totals, kpm: teamKpm, apm: teamApm, spm: teamSpm, cpm: teamCpm, rpm: teamRpm };
+
+        const totalsData = teamStats.totals || {};
+        const totalKills = totalsData.kills ?? totals.kills;
+        const totalAssists = totalsData.assists ?? totals.assists;
+        const totalScore = totalsData.score ?? totals.score;
+        const totalCaptures = totalsData.captures ?? totals.captures;
+        const totalReturns = totalsData.returns ?? totals.returns;
+        const totalTime = totalsData.time ?? totals.time;
+        const teamKpm = totalTime ? (totalKills / totalTime).toFixed(2) : (totalsData.kpm ?? '0');
+        const teamApm = totalTime ? (totalAssists / totalTime).toFixed(2) : (totalsData.apm ?? '0');
+        const teamSpm = totalTime ? (totalScore / totalTime).toFixed(2) : (totalsData.spm ?? '0');
+        const teamCpm = totalTime ? (totalCaptures / totalTime).toFixed(2) : (totalsData.cpm ?? '0');
+        const teamRpm = totalTime ? (totalReturns / totalTime).toFixed(2) : (totalsData.rpm ?? '0');
+
         const trTot = document.createElement('tr');
         trTot.className = 'font-semibold';
         trTot.innerHTML = `
           <td class="px-2">${teamName}</td>
           <td class="px-2">Totals</td>
-          <td class="px-2">${totals.kills}</td>
-          <td class="px-2">${totals.assists}</td>
-          <td class="px-2">${totals.score}</td>
-          <td class="px-2">${totals.captures}</td>
-          <td class="px-2">${totals.returns}</td>
-          <td class="px-2">${totals.time}</td>
+          <td class="px-2">${totalKills}</td>
+          <td class="px-2">${totalAssists}</td>
+          <td class="px-2">${totalScore}</td>
+          <td class="px-2">${totalCaptures}</td>
+          <td class="px-2">${totalReturns}</td>
+          <td class="px-2">${totalTime}</td>
           <td class="px-2">${teamKpm}</td>
           <td class="px-2">${teamApm}</td>
           <td class="px-2">${teamSpm}</td>
@@ -445,8 +512,23 @@
         `;
         tbody.appendChild(trTot);
       });
+
       output.appendChild(exportTable);
       document.getElementById('exportBtn').disabled = false;
+    }
+
+    document.getElementById('saveMatch').addEventListener('click', async () => {
+      const map = document.getElementById('map').value;
+      const t1 = teamsData.find(t => t.id === document.getElementById('team1').value);
+      const t2 = teamsData.find(t => t.id === document.getElementById('team2').value);
+      if (!t1 || !t2) {
+        alert('Please select two teams before saving.');
+        return;
+      }
+
+      const saveData = buildSaveData(map, t1, t2);
+      renderRunningTotals(saveData.stats);
+
       if (editingMatchId) {
         await updateDoc(doc(db, 'matches', editingMatchId), saveData);
         alert('Match updated!');


### PR DESCRIPTION
## Summary
- add helpers to reuse stat collection and output rendering
- automatically render running totals when loading a saved match or saving new data
- clear the output when starting a fresh match or deleting the active one

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68dabce9da80832abba4cf4be5ed2e87