### PR TITLE
Fix MatchStats admin save handler syntax error

### DIFF
--- a/MatchStatsAdmin.html
+++ b/MatchStatsAdmin.html
@@ -767,29 +767,18 @@
       const saveData = buildSaveData(map, t1, t2);
       renderRunningTotals(saveData.stats, formatMatchMeta(saveData));
 
+      let actionMessage = 'Match saved!';
       try {
         if (editingMatchId) {
           await updateDoc(doc(db, 'matches', editingMatchId), saveData);
+          actionMessage = 'Match updated!';
         } else {
           await addDoc(collection(db, 'matches'), saveData);
         }
       } catch (err) {
         console.error('Failed to save match', err);
         alert('Failed to save match. Please try again.');
-
         return;
-      }
-
-      const saveData = buildSaveData(map, t1, t2);
-      renderRunningTotals(saveData.stats, formatMatchMeta(saveData));
-
-      if (editingMatchId) {
-        await updateDoc(doc(db, 'matches', editingMatchId), saveData);
-        alert('Match updated!');
-      } else {
-        await addDoc(collection(db, 'matches'), saveData);
-        alert('Match saved!');
-
       }
 
       let rebuildError = null;
@@ -806,9 +795,9 @@
       loadMatches();
 
       if (rebuildError) {
-        alert('Match saved, but updating the public stats snapshot failed. Please try saving again to refresh the stats.');
+        alert(`${actionMessage} However, updating the public stats snapshot failed. Please try saving again to refresh the stats.`);
       } else {
-        alert('Match saved! Public stats have been refreshed.');
+        alert(`${actionMessage} Public stats have been refreshed.`);
       }
     });
 


### PR DESCRIPTION
## Summary
- remove the duplicate save-match logic that redefined `saveData`, which prevented the module from loading
- streamline the save handler to show success messaging while still rebuilding the public stats snapshot

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68daca887278832abb947652c500cd9c