### PR TITLE
Align chat widget with right-side layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,7 +618,7 @@
     }
     #chat-panel {
       position: fixed;
-      left: max(var(--page-gutter), calc((100vw - var(--page-max-width)) / 2 + var(--page-gutter)));
+      right: max(var(--page-gutter), calc((100vw - var(--page-max-width)) / 2 + var(--page-gutter)));
 
       top: 3.5rem;
       width: var(--chat-panel-width);
@@ -676,7 +676,7 @@
     #chat-toggle {
       position: fixed;
       bottom: 1.5rem;
-      left: max(var(--page-gutter), calc((100vw - var(--page-max-width)) / 2 + var(--page-gutter)));
+      right: max(var(--page-gutter), calc((100vw - var(--page-max-width)) / 2 + var(--page-gutter)));
 
       width: 54px;
       height: 54px;
@@ -887,7 +887,7 @@
       .control-panel { padding: 1.2rem; }
       nav#global-header { padding: 0.75rem 1rem; }
       main { padding: 1.2rem 1rem 4rem; }
-      #chat-toggle { bottom: 1rem; left: 1rem; }
+      #chat-toggle { bottom: 1rem; right: 1rem; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- anchor the fixed chat panel to the right-hand gutter so it matches the original placement
- keep the chat toggle button aligned to the right on both desktop and mobile breakpoints

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68dd7d89d0c8832a84395580b9a6b051