### PR TITLE
Add VS matchup image rendering for match headers

### DIFF
--- a/MatchDetails.html
+++ b/MatchDetails.html
@@ -6,6 +6,33 @@
   <title>TPL Match Details</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="oauth.js"></script>
+  <style>
+    .poll-subhead {
+      display: flex;
+      align-items: center;
+      min-height: 2.75rem;
+    }
+    .poll-subhead .poll-subhead-text {
+      display: inline-block;
+    }
+    .poll-subhead .vs-image {
+      display: inline-flex;
+      gap: 0.75rem;
+      justify-content: flex-start;
+      max-width: 100%;
+    }
+    .poll-subhead .vs-image img {
+      display: block;
+      max-width: min(100%, 360px);
+      height: auto;
+      filter: drop-shadow(0 18px 28px -22px rgba(15, 23, 42, 0.7));
+    }
+    .poll-subhead .vs-image__fallback {
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+  </style>
 </head>
 <body class="bg-slate-950 text-slate-100 min-h-screen">
   <div id="nav-placeholder" data-include="nav.html"></div>
@@ -27,7 +54,9 @@
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div>
             <h2 class="text-2xl font-semibold text-white">Who will win?</h2>
-            <p id="pollSubhead" class="text-sm text-slate-400">Cast your vote to back your team.</p>
+            <div id="pollSubhead" class="poll-subhead text-sm text-slate-400">
+              <span class="poll-subhead-text">Cast your vote to back your team.</span>
+            </div>
           </div>
           <p id="pollStatus" class="text-sm text-slate-400">Loading votes…</p>
         </div>
@@ -115,6 +144,7 @@
       setDoc,
       serverTimestamp
     } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js';
+    import { createVsImage } from './src/components/VsImage.js';
 
     const firebaseConfig = {
       apiKey: 'AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM',
@@ -185,6 +215,198 @@
     let currentUser = null;
     let currentUserVote = null;
     let savingVote = false;
+
+    const teamMetaCache = new Map();
+    const slugPersistAttempts = new Set();
+    const missingSlugWarnings = new Set();
+    const VS_IMAGE_BASE_PATH = "TribesLeagueLogo's/TeamMatchUps";
+    const VS_IMAGE_FALLBACK_SRC = '';
+    const POLL_LOADING_SUBHEAD = 'Loading matchup…';
+
+    function sanitizeSlug(value) {
+      if (!value) return '';
+      return String(value)
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^A-Za-z0-9]/g, '')
+        .toUpperCase();
+    }
+
+    function pickSlug(...values) {
+      for (const value of values) {
+        const slug = sanitizeSlug(value);
+        if (slug) return slug;
+      }
+      return '';
+    }
+
+    function toTeamDocRef(value) {
+      if (!value) return null;
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed ? doc(db, 'teams', trimmed) : null;
+      }
+      if (typeof value === 'object') {
+        if (value?.path && value?.id && typeof value.path === 'string') {
+          return value;
+        }
+        if (value?.id && typeof value.id === 'string') {
+          return doc(db, 'teams', value.id);
+        }
+      }
+      return null;
+    }
+
+    async function fetchTeamRecord(rawValue) {
+      const docRef = toTeamDocRef(rawValue);
+      if (!docRef) return null;
+      const cacheKey = docRef.path || docRef.id;
+      if (teamMetaCache.has(cacheKey)) {
+        return teamMetaCache.get(cacheKey);
+      }
+      try {
+        const snap = await getDoc(docRef);
+        if (!snap.exists()) {
+          teamMetaCache.set(cacheKey, null);
+          return null;
+        }
+        const data = snap.data() || {};
+        const teamName = data.teamName || data.name || data.displayName || data.team || docRef.id;
+        let slug = sanitizeSlug(data.slug);
+        if (!slug) {
+          slug = pickSlug(
+            data.teamTag,
+            data.tag,
+            data.abbreviation,
+            data.abbrev,
+            teamName,
+            docRef.id
+          );
+          if (slug && !data.slug && !slugPersistAttempts.has(cacheKey)) {
+            slugPersistAttempts.add(cacheKey);
+            setDoc(docRef, { slug }, { merge: true }).catch(() => {});
+          }
+        }
+        const record = { id: docRef.id, name: teamName, slug, data };
+        teamMetaCache.set(cacheKey, record);
+        return record;
+      } catch (err) {
+        console.warn('Failed to fetch team metadata', rawValue, err);
+        teamMetaCache.set(cacheKey, null);
+        return null;
+      }
+    }
+
+    function setPollSubheadContent(content) {
+      if (!pollSubheadEl) return;
+      pollSubheadEl.replaceChildren();
+      if (typeof content === 'string') {
+        const span = document.createElement('span');
+        span.className = 'poll-subhead-text';
+        span.textContent = content;
+        pollSubheadEl.appendChild(span);
+        pollSubheadEl.dataset.state = 'text';
+        return;
+      }
+      if (content instanceof Node) {
+        pollSubheadEl.appendChild(content);
+        pollSubheadEl.dataset.state = content.dataset?.state || 'custom';
+      }
+    }
+
+    function setPollSubheadText(message) {
+      setPollSubheadContent(message);
+    }
+
+    function warnVsFallback(contextKey, details = {}) {
+      const {
+        teamAName,
+        teamBName,
+        teamASlug,
+        teamBSlug,
+        reason,
+        attemptedSrc,
+        teamAId,
+        teamBId
+      } = details;
+      const key = `${contextKey}:${teamASlug || '?'}-${teamBSlug || '?'}:${reason || 'unknown'}`;
+      if (missingSlugWarnings.has(key)) return;
+      missingSlugWarnings.add(key);
+      const payload = {
+        teamA: teamAName || 'Team A',
+        teamB: teamBName || 'Team B',
+        teamAId: teamAId || null,
+        teamBId: teamBId || null,
+        teamASlug: teamASlug || null,
+        teamBSlug: teamBSlug || null
+      };
+      if (attemptedSrc) {
+        payload.asset = attemptedSrc;
+      }
+      console.warn(`[VSImage] Falling back for ${payload.teamA} vs ${payload.teamB} (${contextKey}) due to ${reason || 'unknown'}.`, payload);
+    }
+
+    function renderPollSubheadVs({ teamAName, teamBName, teamASlug, teamBSlug, teamAId, teamBId }) {
+      if (!pollSubheadEl) return;
+      if (!teamASlug || !teamBSlug) {
+        warnVsFallback('match-details', { teamAName, teamBName, teamASlug, teamBSlug, teamAId, teamBId, reason: 'missing-slug' });
+      }
+      const element = createVsImage({
+        teamAName,
+        teamBName,
+        teamASlug,
+        teamBSlug,
+        basePath: VS_IMAGE_BASE_PATH,
+        fallbackSrc: VS_IMAGE_FALLBACK_SRC,
+        className: 'vs-image',
+        fallbackClass: 'poll-subhead-text',
+        onImageError: ({ attemptedSrc }) => {
+          warnVsFallback('match-details', {
+            teamAName,
+            teamBName,
+            teamASlug,
+            teamBSlug,
+            teamAId,
+            teamBId,
+            reason: 'image-error',
+            attemptedSrc
+          });
+        }
+      });
+      setPollSubheadContent(element);
+    }
+
+    function extractTeamReference(matchData, side) {
+      if (!matchData) return null;
+      const prefix = (side || 'A').toUpperCase() === 'B' ? 'B' : 'A';
+      const altKeys = prefix === 'A' ? ['home', 'blue'] : ['away', 'red'];
+      const candidates = [
+        matchData[`team${prefix}Id`],
+        matchData[`team${prefix}ID`],
+        matchData[`team${prefix}`]?.id,
+        matchData[`team${prefix}`]?.teamId,
+        matchData[`team${prefix}`]?.ref,
+        matchData[`team${prefix}`]?.doc,
+        matchData[`team${prefix}Ref`],
+        matchData[`team${prefix}Doc`],
+        matchData[`${prefix.toLowerCase()}TeamId`],
+        matchData[`${altKeys[0]}Id`],
+        matchData[`${altKeys[0]}ID`],
+        matchData[`${altKeys[0]}TeamId`],
+        matchData[`${altKeys[0]}TeamID`],
+        matchData[`${altKeys[0]}Team`]?.id,
+        matchData[`${altKeys[0]}Team`]?.teamId,
+        matchData[`${altKeys[1]}Id`],
+        matchData[`${altKeys[1]}ID`],
+        matchData[`${altKeys[1]}TeamId`],
+        matchData[`${altKeys[1]}Team`]?.id,
+        matchData[`${altKeys[1]}Team`]?.teamId
+      ];
+      for (const candidate of candidates) {
+        if (candidate) return candidate;
+      }
+      return null;
+    }
 
     function formatDate(value) {
       if (!value) return '—';
@@ -371,10 +593,11 @@
     }
 
     async function loadMatch() {
+      setPollSubheadText(POLL_LOADING_SUBHEAD);
       if (!matchId) {
         matchTitleEl.textContent = 'Match not found';
         matchMetaEl.textContent = 'Missing matchId parameter in the URL.';
-        pollSubheadEl.textContent = 'Provide a valid match link to vote.';
+        setPollSubheadText('Provide a valid match link to vote.');
         setLoadingState(false);
         pollStatusEl.textContent = 'Unable to load votes.';
         pollOptionsEl.classList.add('pointer-events-none', 'opacity-50');
@@ -387,7 +610,7 @@
         if (!snap.exists()) {
           matchTitleEl.textContent = 'Match not found';
           matchMetaEl.textContent = 'This match could not be located. It may have been removed.';
-          pollSubheadEl.textContent = 'Unable to load teams for this match.';
+          setPollSubheadText('Unable to load teams for this match.');
           setLoadingState(false);
           pollOptionsEl.classList.add('pointer-events-none', 'opacity-50');
           return;
@@ -395,21 +618,65 @@
 
         currentMatch = snap.data();
         const { team1, team2, map, created } = currentMatch;
+        const teamAName = team1 ?? currentMatch.teamA ?? currentMatch.teamAName ?? currentMatch.home ?? currentMatch.blue ?? 'Team A';
+        const teamBName = team2 ?? currentMatch.teamB ?? currentMatch.teamBName ?? currentMatch.away ?? currentMatch.red ?? 'Team B';
 
-        breadcrumbEl.textContent = `Match • ${team1 ?? 'Team A'} vs ${team2 ?? 'Team B'}`;
-        matchTitleEl.textContent = `${team1 ?? 'Team A'} vs ${team2 ?? 'Team B'}`;
+        breadcrumbEl.textContent = `Match • ${teamAName} vs ${teamBName}`;
+        matchTitleEl.textContent = `${teamAName} vs ${teamBName}`;
         matchMetaEl.textContent = map ? `Map: ${map}` : 'Map not recorded';
 
-        detailMatchupEl.textContent = `${team1 ?? 'Team A'} vs ${team2 ?? 'Team B'}`;
+        detailMatchupEl.textContent = `${teamAName} vs ${teamBName}`;
         detailMapEl.textContent = map ?? '—';
         detailCreatedEl.textContent = formatDate(created);
         matchDetailsStatusEl.textContent = 'Stats summary will be available soon.';
 
-        teamNameSpans.A.textContent = team1 ?? 'Team A';
-        teamNameSpans.B.textContent = team2 ?? 'Team B';
-        progressNames.A.textContent = team1 ?? 'Team A';
-        progressNames.B.textContent = team2 ?? 'Team B';
-        pollSubheadEl.textContent = `Vote between ${team1 ?? 'Team A'} and ${team2 ?? 'Team B'}.`;
+        teamNameSpans.A.textContent = teamAName;
+        teamNameSpans.B.textContent = teamBName;
+        progressNames.A.textContent = teamAName;
+        progressNames.B.textContent = teamBName;
+
+        const teamARef = extractTeamReference(currentMatch, 'A');
+        const teamBRef = extractTeamReference(currentMatch, 'B');
+        const [teamAMeta, teamBMeta] = await Promise.all([
+          fetchTeamRecord(teamARef),
+          fetchTeamRecord(teamBRef)
+        ]);
+        const teamASlug = pickSlug(
+          teamAMeta?.slug,
+          currentMatch.teamASlug,
+          currentMatch.teamA_slug,
+          currentMatch.teamATag,
+          currentMatch.team1Tag,
+          currentMatch.team1Slug,
+          currentMatch.homeTag,
+          currentMatch.homeSlug,
+          currentMatch.blueTag,
+          currentMatch.blueSlug,
+          teamAName
+        );
+        const teamBSlug = pickSlug(
+          teamBMeta?.slug,
+          currentMatch.teamBSlug,
+          currentMatch.teamB_slug,
+          currentMatch.teamBTag,
+          currentMatch.team2Tag,
+          currentMatch.team2Slug,
+          currentMatch.awayTag,
+          currentMatch.awaySlug,
+          currentMatch.redTag,
+          currentMatch.redSlug,
+          teamBName
+        );
+        const teamAId = teamAMeta?.id || (typeof teamARef === 'string' ? teamARef : teamARef?.id);
+        const teamBId = teamBMeta?.id || (typeof teamBRef === 'string' ? teamBRef : teamBRef?.id);
+        renderPollSubheadVs({
+          teamAName,
+          teamBName,
+          teamASlug,
+          teamBSlug,
+          teamAId,
+          teamBId
+        });
 
         setLoadingState(false);
         updateVoteUI();
@@ -418,7 +685,7 @@
         console.error('Failed to load match', err);
         matchTitleEl.textContent = 'Match unavailable';
         matchMetaEl.textContent = 'We ran into an error loading this match.';
-        pollSubheadEl.textContent = 'Please refresh and try again.';
+        setPollSubheadText('Please refresh and try again.');
         setLoadingState(false);
         showError('Unable to load match details.');
       }

--- a/index.html
+++ b/index.html
@@ -860,7 +860,19 @@
       font-weight: 700;
       letter-spacing: -0.01em;
     }
-    .match-poll__subhead,
+    .match-poll__subhead {
+      margin: 0;
+      color: rgba(226, 232, 240, 0.72);
+      font-size: 0.9rem;
+      line-height: 1.45;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      min-height: 3rem;
+    }
+    .match-poll__subhead > * {
+      flex: 1 1 auto;
+    }
     .match-poll__meta,
     .match-poll__status {
       margin: 0;
@@ -869,6 +881,40 @@
       line-height: 1.45;
     }
     .match-poll__status { font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: rgba(148, 163, 184, 0.9); }
+    .match-poll__subhead-text {
+      display: inline-block;
+    }
+    .vs-image {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      max-width: 100%;
+    }
+    .vs-image img {
+      display: block;
+      max-width: min(100%, 420px);
+      height: auto;
+      filter: drop-shadow(0 24px 36px -20px rgba(15, 23, 42, 0.65));
+    }
+    .vs-image[data-state="text"] {
+      width: 100%;
+    }
+    .vs-image__fallback {
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(226, 232, 240, 0.82);
+    }
+    .match-poll__subhead .vs-image {
+      justify-content: flex-start;
+    }
+    .match-poll__subhead .vs-image__fallback {
+      color: rgba(226, 232, 240, 0.72);
+      font-size: 0.9rem;
+      letter-spacing: 0.04em;
+      line-height: 1.45;
+    }
     .match-poll__content { display: grid; gap: 1.25rem; }
     .match-poll__loading {
       display: grid;
@@ -1042,7 +1088,9 @@
             <div class="match-poll__heading">
               <p class="match-poll__eyebrow">Featured Match</p>
               <h2 class="match-poll__title">Who will win?</h2>
-              <p class="match-poll__subhead" id="match-poll-subhead">Loading featured matchup…</p>
+              <div class="match-poll__subhead" id="match-poll-subhead">
+                <span class="match-poll__subhead-text">Loading featured matchup…</span>
+              </div>
               <p class="match-poll__meta is-hidden" id="match-poll-meta"></p>
             </div>
             <p class="match-poll__status" id="match-poll-status">Loading votes…</p>
@@ -1171,6 +1219,7 @@
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
     import { getFirestore, collection, getDocs, query, where, doc, getDoc, onSnapshot, setDoc, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+    import { createVsImage } from "./src/components/VsImage.js";
 
     const firebaseConfig = {
       apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
@@ -1296,6 +1345,12 @@
     };
 
     const teamIndex = new Map();
+    const teamMetaCache = new Map();
+    const slugPersistAttempts = new Set();
+    const missingSlugWarnings = new Set();
+    const VS_IMAGE_BASE_PATH = "TribesLeagueLogo's/TeamMatchUps";
+    const VS_IMAGE_FALLBACK_SRC = "";
+    const MATCH_POLL_LOADING_TEXT = "Loading featured matchup…";
 
     const pollEls = els.matchPoll || {};
     const pollState = {
@@ -1310,6 +1365,191 @@
       hasError: false,
       cleanupBound: false
     };
+
+    function sanitizeSlug(value) {
+      if (!value) return "";
+      return String(value)
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/[^A-Za-z0-9]/g, "")
+        .toUpperCase();
+    }
+
+    function pickSlug(...values) {
+      for (const value of values) {
+        const slug = sanitizeSlug(value);
+        if (slug) return slug;
+      }
+      return "";
+    }
+
+    function toTeamDocRef(value) {
+      if (!value) return null;
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        return trimmed ? doc(db, "teams", trimmed) : null;
+      }
+      if (typeof value === "object") {
+        if (value?.path && value?.id && typeof value.path === "string") {
+          return value;
+        }
+        if (value?.id && typeof value.id === "string") {
+          return doc(db, "teams", value.id);
+        }
+      }
+      return null;
+    }
+
+    async function fetchTeamRecord(rawValue) {
+      const docRef = toTeamDocRef(rawValue);
+      if (!docRef) return null;
+      const cacheKey = docRef.path || docRef.id;
+      if (teamMetaCache.has(cacheKey)) {
+        return teamMetaCache.get(cacheKey);
+      }
+      try {
+        const snap = await getDoc(docRef);
+        if (!snap.exists()) {
+          teamMetaCache.set(cacheKey, null);
+          return null;
+        }
+        const data = snap.data() || {};
+        const teamName = data.teamName || data.name || data.displayName || data.team || docRef.id;
+        let slug = sanitizeSlug(data.slug);
+        if (!slug) {
+          slug = pickSlug(
+            data.teamTag,
+            data.tag,
+            data.abbreviation,
+            data.abbrev,
+            teamName,
+            docRef.id
+          );
+          if (slug && !data.slug && !slugPersistAttempts.has(cacheKey)) {
+            slugPersistAttempts.add(cacheKey);
+            setDoc(docRef, { slug }, { merge: true }).catch(() => {});
+          }
+        }
+        const record = { id: docRef.id, name: teamName, slug, data };
+        teamMetaCache.set(cacheKey, record);
+        return record;
+      } catch (err) {
+        console.warn("Failed to fetch team metadata", rawValue, err);
+        teamMetaCache.set(cacheKey, null);
+        return null;
+      }
+    }
+
+    function setMatchSubheadContent(content) {
+      if (!pollEls.subhead) return;
+      pollEls.subhead.replaceChildren();
+      if (typeof content === "string") {
+        const span = document.createElement("span");
+        span.className = "match-poll__subhead-text";
+        span.textContent = content;
+        pollEls.subhead.appendChild(span);
+        pollEls.subhead.dataset.state = "text";
+        return;
+      }
+      if (content instanceof Node) {
+        pollEls.subhead.appendChild(content);
+        pollEls.subhead.dataset.state = content.dataset?.state || "custom";
+      }
+    }
+
+    function setMatchSubheadText(message) {
+      setMatchSubheadContent(message);
+    }
+
+    function warnMissingSlug(contextKey, details = {}) {
+      const {
+        teamAName,
+        teamBName,
+        teamASlug,
+        teamBSlug,
+        reason,
+        attemptedSrc,
+        teamAId,
+        teamBId
+      } = details;
+      const key = `${contextKey}:${teamASlug || "?"}-${teamBSlug || "?"}:${reason || "unknown"}`;
+      if (missingSlugWarnings.has(key)) return;
+      missingSlugWarnings.add(key);
+      const payload = {
+        teamA: teamAName || "Team A",
+        teamB: teamBName || "Team B",
+        teamAId: teamAId || null,
+        teamBId: teamBId || null,
+        teamASlug: teamASlug || null,
+        teamBSlug: teamBSlug || null
+      };
+      if (attemptedSrc) {
+        payload.asset = attemptedSrc;
+      }
+      console.warn(`[VSImage] Falling back for ${payload.teamA} vs ${payload.teamB} (${contextKey}) due to ${reason || "unknown"}.`, payload);
+    }
+
+    function renderMatchSubheadVs({ teamAName, teamBName, teamASlug, teamBSlug, teamAId, teamBId }) {
+      if (!pollEls.subhead) return;
+      if (!teamASlug || !teamBSlug) {
+        warnMissingSlug("match-poll", { teamAName, teamBName, teamASlug, teamBSlug, teamAId, teamBId, reason: "missing-slug" });
+      }
+      const element = createVsImage({
+        teamAName,
+        teamBName,
+        teamASlug,
+        teamBSlug,
+        basePath: VS_IMAGE_BASE_PATH,
+        fallbackSrc: VS_IMAGE_FALLBACK_SRC,
+        className: "vs-image",
+        fallbackClass: "match-poll__subhead-text",
+        onImageError: ({ attemptedSrc }) => {
+          warnMissingSlug("match-poll", {
+            teamAName,
+            teamBName,
+            teamASlug,
+            teamBSlug,
+            teamAId,
+            teamBId,
+            reason: "image-error",
+            attemptedSrc
+          });
+        }
+      });
+      setMatchSubheadContent(element);
+    }
+
+    function extractTeamReference(matchData, side) {
+      if (!matchData) return null;
+      const prefix = (side || "A").toUpperCase() === "B" ? "B" : "A";
+      const altKeys = prefix === "A" ? ["home", "blue"] : ["away", "red"];
+      const candidates = [
+        matchData[`team${prefix}Id`],
+        matchData[`team${prefix}ID`],
+        matchData[`team${prefix}`]?.id,
+        matchData[`team${prefix}`]?.teamId,
+        matchData[`team${prefix}`]?.ref,
+        matchData[`team${prefix}`]?.doc,
+        matchData[`team${prefix}Ref`],
+        matchData[`team${prefix}Doc`],
+        matchData[`${prefix.toLowerCase()}TeamId`],
+        matchData[`${altKeys[0]}Id`],
+        matchData[`${altKeys[0]}ID`],
+        matchData[`${altKeys[0]}TeamId`],
+        matchData[`${altKeys[0]}TeamID`],
+        matchData[`${altKeys[0]}Team`]?.id,
+        matchData[`${altKeys[0]}Team`]?.teamId,
+        matchData[`${altKeys[1]}Id`],
+        matchData[`${altKeys[1]}ID`],
+        matchData[`${altKeys[1]}TeamId`],
+        matchData[`${altKeys[1]}Team`]?.id,
+        matchData[`${altKeys[1]}Team`]?.teamId
+      ];
+      for (const candidate of candidates) {
+        if (candidate) return candidate;
+      }
+      return null;
+    }
 
     function pollEnabled() {
       return Boolean(pollEls?.container);
@@ -1527,9 +1767,11 @@
     }
 
     async function loadPollMatch() {
+      setMatchSubheadText(MATCH_POLL_LOADING_TEXT);
       if (!pollEnabled() || !pollState.matchId) {
         setPollLoading(false);
         setPollStatus("No match selected.");
+        setMatchSubheadText("No match selected.");
         pollState.matchLoaded = false;
         updatePollInteractivity();
         return false;
@@ -1546,6 +1788,7 @@
           updatePollUI();
           setPollLoading(false);
           setPollStatus("Match not found.");
+          setMatchSubheadText("Match not found.");
           setPollError("We couldn't find that match. Update the featured match ID to continue.");
           if (pollState.unsubscribe) {
             pollState.unsubscribe();
@@ -1571,9 +1814,48 @@
           if (pollEls.progressLabels.A) pollEls.progressLabels.A.textContent = pollState.teams.A;
           if (pollEls.progressLabels.B) pollEls.progressLabels.B.textContent = pollState.teams.B;
         }
-        if (pollEls.subhead) {
-          pollEls.subhead.textContent = `${pollState.teams.A} vs ${pollState.teams.B}`;
-        }
+        const teamARef = extractTeamReference(data, "A");
+        const teamBRef = extractTeamReference(data, "B");
+        const [teamAMeta, teamBMeta] = await Promise.all([
+          fetchTeamRecord(teamARef),
+          fetchTeamRecord(teamBRef)
+        ]);
+        const teamASlug = pickSlug(
+          teamAMeta?.slug,
+          data.teamASlug,
+          data.teamA_slug,
+          data.teamATag,
+          data.team1Tag,
+          data.team1Slug,
+          data.homeTag,
+          data.homeSlug,
+          data.blueTag,
+          data.blueSlug,
+          pollState.teams.A
+        );
+        const teamBSlug = pickSlug(
+          teamBMeta?.slug,
+          data.teamBSlug,
+          data.teamB_slug,
+          data.teamBTag,
+          data.team2Tag,
+          data.team2Slug,
+          data.awayTag,
+          data.awaySlug,
+          data.redTag,
+          data.redSlug,
+          pollState.teams.B
+        );
+        const teamAId = teamAMeta?.id || (typeof teamARef === "string" ? teamARef : teamARef?.id);
+        const teamBId = teamBMeta?.id || (typeof teamBRef === "string" ? teamBRef : teamBRef?.id);
+        renderMatchSubheadVs({
+          teamAName: pollState.teams.A,
+          teamBName: pollState.teams.B,
+          teamASlug,
+          teamBSlug,
+          teamAId,
+          teamBId
+        });
 
         const mapName = data.map ?? data.mapName ?? data.stage ?? "";
         const matchDate = formatMatchDate(data.scheduled ?? data.startTime ?? data.kickoff ?? data.date ?? data.created ?? "");
@@ -1597,6 +1879,7 @@
         updatePollUI();
         setPollLoading(false);
         setPollStatus("Match unavailable.");
+        setMatchSubheadText("Unable to load matchup.");
         setPollError("Unable to load match details. Please refresh and try again.");
         updatePollInteractivity();
         return false;

--- a/src/components/VsImage.js
+++ b/src/components/VsImage.js
@@ -1,0 +1,88 @@
+const DEFAULT_CLASS = 'vs-image';
+const DEFAULT_FALLBACK_CLASS = 'vs-image__fallback';
+
+function createTextFallback(label, fallbackClass) {
+  const span = document.createElement('span');
+  span.className = fallbackClass || DEFAULT_FALLBACK_CLASS;
+  span.textContent = label;
+  return span;
+}
+
+function buildImageSrc(basePath, teamASlug, teamBSlug) {
+  const trimmedBase = String(basePath || '').replace(/\/$/, '');
+  return `${trimmedBase}/${teamASlug}vs${teamBSlug}.png`;
+}
+
+export function createVsImage(options = {}) {
+  const {
+    teamAName = 'Team A',
+    teamBName = 'Team B',
+    teamASlug,
+    teamBSlug,
+    basePath = "TribesLeagueLogo's/TeamMatchUps",
+    fallbackSrc = '',
+    className = DEFAULT_CLASS,
+    fallbackClass = DEFAULT_FALLBACK_CLASS,
+    imageClass = '',
+    onImageError
+  } = options;
+
+  const label = `${teamAName} vs ${teamBName}`;
+  const container = document.createElement('div');
+  container.className = className || DEFAULT_CLASS;
+  container.dataset.state = 'init';
+  container.setAttribute('role', 'img');
+  container.setAttribute('aria-label', label);
+
+  const normalizedTeamASlug = typeof teamASlug === 'string' ? teamASlug.trim() : '';
+  const normalizedTeamBSlug = typeof teamBSlug === 'string' ? teamBSlug.trim() : '';
+  const haveSlugs = normalizedTeamASlug && normalizedTeamBSlug;
+
+  if (!haveSlugs) {
+    container.dataset.state = 'text';
+    container.appendChild(createTextFallback(label, fallbackClass));
+    return container;
+  }
+
+  const image = document.createElement('img');
+  image.src = buildImageSrc(basePath, normalizedTeamASlug, normalizedTeamBSlug);
+  image.alt = label;
+  image.loading = 'lazy';
+  image.decoding = 'async';
+  if (imageClass) {
+    image.className = imageClass;
+  }
+
+  let triedFallbackSrc = false;
+  const applyTextFallback = () => {
+    container.dataset.state = 'text';
+    container.innerHTML = '';
+    container.appendChild(createTextFallback(label, fallbackClass));
+  };
+
+  image.addEventListener('error', () => {
+    if (fallbackSrc && !triedFallbackSrc) {
+      triedFallbackSrc = true;
+      image.src = fallbackSrc;
+      return;
+    }
+    if (typeof onImageError === 'function') {
+      try {
+        onImageError({ label, attemptedSrc: image.currentSrc || image.src });
+      } catch (err) {
+        // Ignore handler errors to keep this component presentational.
+      }
+    }
+    applyTextFallback();
+  });
+
+  image.addEventListener('load', () => {
+    container.dataset.state = 'image';
+  });
+
+  container.dataset.state = 'loading';
+  container.appendChild(image);
+  return container;
+}
+
+export default createVsImage;


### PR DESCRIPTION
## Summary
- add a reusable `VsImage` component for rendering "Team A vs Team B" matchup graphics with graceful fallbacks
- update the live hub featured match poll to hydrate team slugs from Firestore, persist missing slugs, and display the matchup image with logging on fallback
- apply the same matchup image rendering to the match details page, including styles and loading states for the poll header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddedf7acec832ab2cf52d1c9c3b76a