### PR TITLE
Allow authenticated users to vote in match polls

### DIFF
--- a/MatchDetails.html
+++ b/MatchDetails.html
@@ -1,0 +1,453 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TPL Match Details</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-100 min-h-screen">
+  <div id="nav-placeholder" data-include="nav.html"></div>
+  <main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
+    <header class="space-y-2">
+      <p id="matchBreadcrumb" class="text-sm text-slate-400">Match</p>
+      <h1 id="matchTitle" class="text-3xl sm:text-4xl font-bold tracking-tight text-white">Loading match…</h1>
+      <p id="matchMeta" class="text-sm text-slate-400">Fetching match details.</p>
+    </header>
+
+    <section id="pollSection" class="bg-slate-900/70 border border-slate-800 rounded-2xl p-6 shadow-xl">
+      <div id="pollLoading" class="animate-pulse space-y-4">
+        <div class="h-6 bg-slate-800 rounded w-48"></div>
+        <div class="h-12 bg-slate-800/80 rounded-xl"></div>
+        <div class="h-12 bg-slate-800/80 rounded-xl"></div>
+      </div>
+
+      <div id="pollContent" class="hidden">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <h2 class="text-2xl font-semibold text-white">Who will win?</h2>
+            <p id="pollSubhead" class="text-sm text-slate-400">Cast your vote to back your team.</p>
+          </div>
+          <p id="pollStatus" class="text-sm text-slate-400">Loading votes…</p>
+        </div>
+
+        <div id="pollLogin" class="mt-5 hidden">
+          <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+            <p class="text-sm text-slate-300">Log in to vote for your winner.</p>
+            <button id="pollLoginBtn" class="mt-3 inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-purple-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400">
+              <span>Sign in with Twitch</span>
+            </button>
+          </div>
+        </div>
+
+        <div id="pollOptions" class="mt-5 grid gap-3 sm:grid-cols-2">
+          <button id="voteOptionA" type="button" class="vote-option flex items-center justify-between gap-3 rounded-2xl border border-slate-800 bg-slate-900/40 px-4 py-4 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400">
+            <span class="flex-1">
+              <span class="block text-xs uppercase tracking-wide text-slate-400">Team A</span>
+              <span class="block text-lg font-semibold text-white" data-team-name>A Team</span>
+            </span>
+            <span class="text-sm font-medium text-slate-300" data-team-count>0 votes</span>
+          </button>
+          <button id="voteOptionB" type="button" class="vote-option flex items-center justify-between gap-3 rounded-2xl border border-slate-800 bg-slate-900/40 px-4 py-4 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400">
+            <span class="flex-1">
+              <span class="block text-xs uppercase tracking-wide text-slate-400">Team B</span>
+              <span class="block text-lg font-semibold text-white" data-team-name>B Team</span>
+            </span>
+            <span class="text-sm font-medium text-slate-300" data-team-count>0 votes</span>
+          </button>
+        </div>
+
+        <div class="mt-6 space-y-4">
+          <div>
+            <div class="flex justify-between text-xs font-medium uppercase tracking-wide text-slate-400">
+              <span id="teamALabel">Team A</span>
+              <span id="teamAPercent">0%</span>
+            </div>
+            <div class="mt-2 h-3 rounded-full bg-slate-800 overflow-hidden">
+              <div id="teamAProgress" class="h-full bg-indigo-500" style="width: 0%"></div>
+            </div>
+          </div>
+          <div>
+            <div class="flex justify-between text-xs font-medium uppercase tracking-wide text-slate-400">
+              <span id="teamBLabel">Team B</span>
+              <span id="teamBPercent">0%</span>
+            </div>
+            <div class="mt-2 h-3 rounded-full bg-slate-800 overflow-hidden">
+              <div id="teamBProgress" class="h-full bg-rose-500" style="width: 0%"></div>
+            </div>
+          </div>
+        </div>
+
+        <p id="pollEmptyState" class="mt-4 text-sm text-slate-400 hidden">No votes yet — be the first to choose a winner!</p>
+        <p id="pollError" class="mt-4 text-sm text-rose-400 hidden"></p>
+      </div>
+    </section>
+
+    <section id="matchDetails" class="bg-slate-900/40 border border-slate-800 rounded-2xl p-6 space-y-4">
+      <h2 class="text-xl font-semibold text-white">Match details</h2>
+      <dl class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <dt class="text-xs uppercase tracking-wide text-slate-400">Matchup</dt>
+          <dd id="detailMatchup" class="text-base font-medium text-slate-100">—</dd>
+        </div>
+        <div>
+          <dt class="text-xs uppercase tracking-wide text-slate-400">Map</dt>
+          <dd id="detailMap" class="text-base font-medium text-slate-100">—</dd>
+        </div>
+        <div>
+          <dt class="text-xs uppercase tracking-wide text-slate-400">Recorded</dt>
+          <dd id="detailCreated" class="text-base font-medium text-slate-100">—</dd>
+        </div>
+      </dl>
+      <p id="matchDetailsStatus" class="text-sm text-slate-400">Loading stats summary…</p>
+    </section>
+  </main>
+
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js';
+    import {
+      getFirestore,
+      doc,
+      getDoc,
+      collection,
+      onSnapshot,
+      setDoc,
+      serverTimestamp
+    } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js';
+
+    const firebaseConfig = {
+      apiKey: 'AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM',
+      authDomain: 'team-sign-up-b5646.firebaseapp.com',
+      projectId: 'team-sign-up-b5646',
+      storageBucket: 'team-sign-up-b5646.firebasestorage.app',
+      messagingSenderId: '951471144681',
+      appId: '1:951471144681:web:a2458675ce73ce9ad9ba78'
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getFirestore(app);
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const matchId = urlParams.get('matchId');
+
+    const matchTitleEl = document.getElementById('matchTitle');
+    const matchMetaEl = document.getElementById('matchMeta');
+    const breadcrumbEl = document.getElementById('matchBreadcrumb');
+    const detailMatchupEl = document.getElementById('detailMatchup');
+    const detailMapEl = document.getElementById('detailMap');
+    const detailCreatedEl = document.getElementById('detailCreated');
+    const matchDetailsStatusEl = document.getElementById('matchDetailsStatus');
+
+    const pollLoadingEl = document.getElementById('pollLoading');
+    const pollContentEl = document.getElementById('pollContent');
+    const pollStatusEl = document.getElementById('pollStatus');
+    const pollSubheadEl = document.getElementById('pollSubhead');
+    const pollLoginEl = document.getElementById('pollLogin');
+    const pollLoginBtn = document.getElementById('pollLoginBtn');
+    const pollOptionsEl = document.getElementById('pollOptions');
+    const pollErrorEl = document.getElementById('pollError');
+    const pollEmptyStateEl = document.getElementById('pollEmptyState');
+
+    const optionButtons = {
+      A: document.getElementById('voteOptionA'),
+      B: document.getElementById('voteOptionB')
+    };
+
+    const teamNameSpans = {
+      A: optionButtons.A.querySelector('[data-team-name]'),
+      B: optionButtons.B.querySelector('[data-team-name]')
+    };
+
+    const teamCountSpans = {
+      A: optionButtons.A.querySelector('[data-team-count]'),
+      B: optionButtons.B.querySelector('[data-team-count]')
+    };
+
+    const percentLabels = {
+      A: document.getElementById('teamAPercent'),
+      B: document.getElementById('teamBPercent')
+    };
+
+    const progressBars = {
+      A: document.getElementById('teamAProgress'),
+      B: document.getElementById('teamBProgress')
+    };
+
+    const progressNames = {
+      A: document.getElementById('teamALabel'),
+      B: document.getElementById('teamBLabel')
+    };
+
+    let currentMatch = null;
+    let unsubscribeVotes = null;
+    let voteCounts = { A: 0, B: 0 };
+    let currentUser = null;
+    let currentUserVote = null;
+    let savingVote = false;
+
+    function formatDate(value) {
+      if (!value) return '—';
+      try {
+        const date = value instanceof Date ? value : value.toDate?.() ?? value;
+        if (!(date instanceof Date)) return '—';
+        return date.toLocaleString(undefined, {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit'
+        });
+      } catch (err) {
+        console.error('Failed to format date', err);
+        return '—';
+      }
+    }
+
+    function showError(message) {
+      pollErrorEl.textContent = message;
+      pollErrorEl.classList.remove('hidden');
+    }
+
+    function clearError() {
+      pollErrorEl.textContent = '';
+      pollErrorEl.classList.add('hidden');
+    }
+
+    function setLoadingState(isLoading) {
+      pollLoadingEl.classList.toggle('hidden', !isLoading);
+      pollContentEl.classList.toggle('hidden', isLoading);
+    }
+
+    function updateVoteUI() {
+      const totalVotes = voteCounts.A + voteCounts.B;
+      const percentA = totalVotes ? Math.round((voteCounts.A / totalVotes) * 100) : 0;
+      const percentB = totalVotes ? 100 - percentA : 0;
+
+      percentLabels.A.textContent = `${percentA}%`;
+      percentLabels.B.textContent = `${percentB}%`;
+
+      progressBars.A.style.width = `${percentA}%`;
+      progressBars.B.style.width = `${percentB}%`;
+
+      teamCountSpans.A.textContent = `${voteCounts.A} vote${voteCounts.A === 1 ? '' : 's'}`;
+      teamCountSpans.B.textContent = `${voteCounts.B} vote${voteCounts.B === 1 ? '' : 's'}`;
+
+      pollEmptyStateEl.classList.toggle('hidden', totalVotes !== 0);
+
+      Object.entries(optionButtons).forEach(([teamKey, button]) => {
+        button.classList.toggle('ring-2', currentUserVote === teamKey);
+        button.classList.toggle('ring-indigo-400', currentUserVote === 'A' && teamKey === 'A');
+        button.classList.toggle('ring-rose-400', currentUserVote === 'B' && teamKey === 'B');
+        button.classList.toggle('border-indigo-400', currentUserVote === 'A' && teamKey === 'A');
+        button.classList.toggle('border-rose-400', currentUserVote === 'B' && teamKey === 'B');
+        button.classList.toggle('bg-indigo-500/10', currentUserVote === 'A' && teamKey === 'A');
+        button.classList.toggle('bg-rose-500/10', currentUserVote === 'B' && teamKey === 'B');
+      });
+
+      let statusText = totalVotes ? `Live votes: ${totalVotes}` : 'No votes cast yet.';
+      if (!currentUser) {
+        statusText = totalVotes
+          ? `Live votes: ${totalVotes} — log in to vote.`
+          : 'Log in to vote and be the first!';
+      }
+      pollStatusEl.textContent = statusText;
+    }
+
+    function setAuthUI(isAuthenticated) {
+      pollLoginEl.classList.toggle('hidden', isAuthenticated);
+      pollOptionsEl.classList.toggle('opacity-50', !isAuthenticated);
+
+      const disableInteractions = !isAuthenticated || savingVote;
+      pollOptionsEl.classList.toggle('pointer-events-none', disableInteractions);
+
+      Object.values(optionButtons).forEach(btn => {
+        btn.disabled = disableInteractions;
+        btn.classList.toggle('cursor-not-allowed', disableInteractions);
+        btn.classList.toggle('cursor-pointer', !disableInteractions);
+      });
+
+      if (!isAuthenticated) {
+        currentUserVote = null;
+        updateVoteUI();
+      }
+    }
+
+    function setSavingState(isSaving) {
+      savingVote = isSaving;
+      if (isSaving) {
+        pollStatusEl.textContent = 'Submitting your vote…';
+      }
+      setAuthUI(Boolean(currentUser));
+    }
+
+    async function refreshUserVote() {
+      if (!currentUser || !matchId) return;
+      try {
+        const voteSnap = await getDoc(doc(db, 'matchVotes', matchId, 'votes', currentUser.id));
+        if (voteSnap.exists()) {
+          currentUserVote = voteSnap.data().team ?? null;
+          updateVoteUI();
+        }
+      } catch (err) {
+        console.error('Failed to load existing vote', err);
+      }
+    }
+
+    async function ensureUser() {
+      if (!window.twitchOAuth || !window.twitchOAuth.getToken()) {
+        currentUser = null;
+        setAuthUI(false);
+        return null;
+      }
+
+      try {
+        currentUser = await window.twitchOAuth.fetchUser();
+      } catch (err) {
+        console.error('Failed to fetch Twitch user', err);
+        currentUser = null;
+      }
+
+      setAuthUI(Boolean(currentUser));
+      if (currentUser) {
+        await refreshUserVote();
+      }
+      return currentUser;
+    }
+
+    async function submitVote(teamKey) {
+      if (!currentMatch) return;
+      if (!currentUser) {
+        setAuthUI(false);
+        return;
+      }
+      if (savingVote) return;
+      if (teamKey === currentUserVote) return;
+
+      clearError();
+      setSavingState(true);
+
+      try {
+        const voteRef = doc(db, 'matchVotes', matchId, 'votes', currentUser.id);
+        const payload = { team: teamKey };
+        if (currentUserVote) {
+          payload.updatedAt = serverTimestamp();
+        } else {
+          payload.createdAt = serverTimestamp();
+        }
+        await setDoc(voteRef, payload, { merge: true });
+        pollStatusEl.textContent = 'Vote saved!';
+      } catch (err) {
+        console.error('Failed to submit vote', err);
+        showError('Unable to save your vote. Please try again.');
+      } finally {
+        setSavingState(false);
+      }
+    }
+
+    function subscribeToVotes() {
+      if (!matchId) return;
+      const votesRef = collection(db, 'matchVotes', matchId, 'votes');
+      unsubscribeVotes = onSnapshot(votesRef, snapshot => {
+        clearError();
+        voteCounts = { A: 0, B: 0 };
+        let userVote = null;
+
+        snapshot.forEach(docSnap => {
+          const data = docSnap.data();
+          if (data.team === 'A') voteCounts.A += 1;
+          if (data.team === 'B') voteCounts.B += 1;
+          if (currentUser && docSnap.id === currentUser.id) {
+            userVote = data.team;
+          }
+        });
+
+        currentUserVote = userVote;
+        updateVoteUI();
+      }, err => {
+        console.error('Failed to subscribe to votes', err);
+        showError('Live vote updates are unavailable right now.');
+      });
+    }
+
+    async function loadMatch() {
+      if (!matchId) {
+        matchTitleEl.textContent = 'Match not found';
+        matchMetaEl.textContent = 'Missing matchId parameter in the URL.';
+        pollSubheadEl.textContent = 'Provide a valid match link to vote.';
+        setLoadingState(false);
+        pollStatusEl.textContent = 'Unable to load votes.';
+        pollOptionsEl.classList.add('pointer-events-none', 'opacity-50');
+        return;
+      }
+
+      try {
+        const matchRef = doc(db, 'matches', matchId);
+        const snap = await getDoc(matchRef);
+        if (!snap.exists()) {
+          matchTitleEl.textContent = 'Match not found';
+          matchMetaEl.textContent = 'This match could not be located. It may have been removed.';
+          pollSubheadEl.textContent = 'Unable to load teams for this match.';
+          setLoadingState(false);
+          pollOptionsEl.classList.add('pointer-events-none', 'opacity-50');
+          return;
+        }
+
+        currentMatch = snap.data();
+        const { team1, team2, map, created } = currentMatch;
+
+        breadcrumbEl.textContent = `Match • ${team1 ?? 'Team A'} vs ${team2 ?? 'Team B'}`;
+        matchTitleEl.textContent = `${team1 ?? 'Team A'} vs ${team2 ?? 'Team B'}`;
+        matchMetaEl.textContent = map ? `Map: ${map}` : 'Map not recorded';
+
+        detailMatchupEl.textContent = `${team1 ?? 'Team A'} vs ${team2 ?? 'Team B'}`;
+        detailMapEl.textContent = map ?? '—';
+        detailCreatedEl.textContent = formatDate(created);
+        matchDetailsStatusEl.textContent = 'Stats summary will be available soon.';
+
+        teamNameSpans.A.textContent = team1 ?? 'Team A';
+        teamNameSpans.B.textContent = team2 ?? 'Team B';
+        progressNames.A.textContent = team1 ?? 'Team A';
+        progressNames.B.textContent = team2 ?? 'Team B';
+        pollSubheadEl.textContent = `Vote between ${team1 ?? 'Team A'} and ${team2 ?? 'Team B'}.`;
+
+        setLoadingState(false);
+        updateVoteUI();
+        subscribeToVotes();
+      } catch (err) {
+        console.error('Failed to load match', err);
+        matchTitleEl.textContent = 'Match unavailable';
+        matchMetaEl.textContent = 'We ran into an error loading this match.';
+        pollSubheadEl.textContent = 'Please refresh and try again.';
+        setLoadingState(false);
+        showError('Unable to load match details.');
+      }
+    }
+
+    optionButtons.A.addEventListener('click', () => submitVote('A'));
+    optionButtons.B.addEventListener('click', () => submitVote('B'));
+
+    pollLoginBtn.addEventListener('click', () => {
+      if (window.twitchOAuth) {
+        window.twitchOAuth.login();
+      }
+    });
+
+    window.addEventListener('storage', event => {
+      if (event.key === 'twitch_token') {
+        ensureUser();
+      }
+    });
+
+    await ensureUser();
+    await loadMatch();
+    setLoadingState(false);
+    updateVoteUI();
+
+    window.addEventListener('beforeunload', () => {
+      if (unsubscribeVotes) unsubscribeVotes();
+    });
+  </script>
+  <script src="./assets/include.js" defer></script>
+</body>
+</html>

--- a/PollAdmin.html
+++ b/PollAdmin.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Match Poll Admin</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="oauth.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen">
+  <div id="nav-placeholder" data-include="nav.html"></div>
+
+  <div id="loginDiv" class="max-w-sm mx-auto mt-10 space-y-4">
+    <h1 class="text-2xl font-bold text-center">Admin Login</h1>
+    <input id="email" type="email" placeholder="Email" class="w-full px-3 py-2 rounded bg-gray-800 border border-gray-700" />
+    <input id="password" type="password" placeholder="Password" class="w-full px-3 py-2 rounded bg-gray-800 border border-gray-700" />
+    <button id="loginBtn" class="w-full py-2 bg-blue-600 hover:bg-blue-700 rounded">Login</button>
+  </div>
+
+  <div id="adminPanel" class="hidden container mx-auto px-4 mt-8 pb-12 space-y-8">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+      <div>
+        <h1 class="text-3xl font-bold">Match Poll Admin</h1>
+        <p class="text-sm text-gray-300">Create upcoming polls and decide which matchup appears on the main hub.</p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <button id="clearActiveBtn" class="px-4 py-2 bg-yellow-600 hover:bg-yellow-700 rounded disabled:opacity-50 disabled:cursor-not-allowed">Clear Active Poll</button>
+        <button id="logoutBtn" class="px-4 py-2 bg-red-600 hover:bg-red-700 rounded">Logout</button>
+      </div>
+    </div>
+
+    <form id="pollForm" class="bg-gray-800 border border-gray-700 rounded-lg p-6 space-y-4">
+      <div class="grid gap-4 md:grid-cols-2">
+        <div class="md:col-span-2">
+          <label for="pollTitle" class="block text-sm mb-1 text-gray-300">Poll Title</label>
+          <input id="pollTitle" type="text" placeholder="Who will win?" class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700" />
+        </div>
+        <div>
+          <label for="teamASelect" class="block text-sm mb-1 text-gray-300">Team A</label>
+          <select id="teamASelect" class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700"></select>
+          <input id="teamAName" type="text" placeholder="Display name" class="mt-2 w-full px-3 py-2 rounded bg-gray-900 border border-gray-700" />
+        </div>
+        <div>
+          <label for="teamBSelect" class="block text-sm mb-1 text-gray-300">Team B</label>
+          <select id="teamBSelect" class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700"></select>
+          <input id="teamBName" type="text" placeholder="Display name" class="mt-2 w-full px-3 py-2 rounded bg-gray-900 border border-gray-700" />
+        </div>
+        <div>
+          <label for="voteId" class="block text-sm mb-1 text-gray-300">Vote Key</label>
+          <input id="voteId" type="text" placeholder="Defaults to poll ID" class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700" />
+          <p class="mt-1 text-xs text-gray-400">Letters, numbers, dashes, and underscores only. Votes are stored under this key.</p>
+        </div>
+        <div>
+          <label for="matchId" class="block text-sm mb-1 text-gray-300">Match Reference</label>
+          <input id="matchId" type="text" placeholder="Optional match document ID" class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700" />
+        </div>
+        <div>
+          <label for="scheduledAt" class="block text-sm mb-1 text-gray-300">Scheduled Date (local)</label>
+          <input id="scheduledAt" type="datetime-local" class="w-full px-3 py-2 rounded bg-gray-900 border border-gray-700" />
+        </div>
+        <div class="flex items-center gap-2 md:col-span-2">
+          <input id="setActive" type="checkbox" class="h-4 w-4" />
+          <label for="setActive" class="text-sm text-gray-300">Set as active on the main hub after saving</label>
+        </div>
+      </div>
+      <div class="flex flex-wrap gap-3">
+        <button id="pollSubmitBtn" type="submit" class="px-4 py-2 bg-green-600 hover:bg-green-700 rounded">Create Poll</button>
+        <button id="pollFormCancel" type="button" class="hidden px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Cancel Edit</button>
+      </div>
+    </form>
+
+    <section>
+      <h2 class="text-2xl font-semibold mb-4">Saved Polls</h2>
+      <div id="pollsList" class="space-y-4"></div>
+    </section>
+  </div>
+
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
+    import {
+      getFirestore,
+      collection,
+      addDoc,
+      getDocs,
+      onSnapshot,
+      query,
+      orderBy,
+      doc,
+      updateDoc,
+      deleteDoc,
+      serverTimestamp,
+      Timestamp,
+      writeBatch
+    } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+    import { getAuth, signInWithEmailAndPassword, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
+      authDomain: "team-sign-up-b5646.firebaseapp.com",
+      projectId: "team-sign-up-b5646",
+      storageBucket: "team-sign-up-b5646.firebasestorage.app",
+      messagingSenderId: "951471144681",
+      appId: "1:951471144681:web:a2458675ce73ce9ad9ba78"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getFirestore(app);
+    const auth = getAuth();
+
+    const ADMIN_UIDS = [
+      "DkBHsCzLK5a9KiX50g0pHJrEqGq2",
+      "A2ZV8vziNsXqZkyqHzAB266B9pP2"
+    ];
+
+    const loginDiv = document.getElementById("loginDiv");
+    const adminPanel = document.getElementById("adminPanel");
+    const loginBtn = document.getElementById("loginBtn");
+    const logoutBtn = document.getElementById("logoutBtn");
+    const clearActiveBtn = document.getElementById("clearActiveBtn");
+
+    const pollForm = document.getElementById("pollForm");
+    const pollSubmitBtn = document.getElementById("pollSubmitBtn");
+    const pollCancelBtn = document.getElementById("pollFormCancel");
+
+    const pollTitleInput = document.getElementById("pollTitle");
+    const teamASelect = document.getElementById("teamASelect");
+    const teamBSelect = document.getElementById("teamBSelect");
+    const teamANameInput = document.getElementById("teamAName");
+    const teamBNameInput = document.getElementById("teamBName");
+    const voteIdInput = document.getElementById("voteId");
+    const matchIdInput = document.getElementById("matchId");
+    const scheduledAtInput = document.getElementById("scheduledAt");
+    const setActiveInput = document.getElementById("setActive");
+    const pollsList = document.getElementById("pollsList");
+
+    const pollsRef = collection(db, "matchPolls");
+    const teamsRef = collection(db, "teams");
+
+    let pollsUnsub = null;
+    let teamsCache = [];
+
+    function escapeHtml(value = "") {
+      return String(value).replace(/[&<>"']/g, ch => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;"
+      })[ch] || ch);
+    }
+
+    function coerceDate(value) {
+      if (!value) return null;
+      if (value instanceof Date) return value;
+      if (value?.toDate) {
+        try {
+          return value.toDate();
+        } catch {
+          return null;
+        }
+      }
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    function formatDateTime(value) {
+      const date = coerceDate(value);
+      if (!date) return "";
+      try {
+        return date.toLocaleString(undefined, {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+          hour: "2-digit",
+          minute: "2-digit"
+        });
+      } catch {
+        return "";
+      }
+    }
+
+    function toInputValue(value) {
+      const date = coerceDate(value);
+      if (!date) return "";
+      const pad = num => String(num).padStart(2, "0");
+      const yyyy = date.getFullYear();
+      const mm = pad(date.getMonth() + 1);
+      const dd = pad(date.getDate());
+      const hh = pad(date.getHours());
+      const min = pad(date.getMinutes());
+      return `${yyyy}-${mm}-${dd}T${hh}:${min}`;
+    }
+
+    function normalizeVoteKey(value = "") {
+      return value
+        .trim()
+        .replace(/[^A-Za-z0-9_-]/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "");
+    }
+
+    function resetForm() {
+      pollForm.reset();
+      pollForm.dataset.editId = "";
+      pollSubmitBtn.textContent = "Create Poll";
+      pollCancelBtn.classList.add("hidden");
+      setActiveInput.checked = false;
+    }
+
+    async function loadTeams() {
+      const snap = await getDocs(teamsRef);
+      teamsCache = snap.docs.map(docSnap => ({
+        id: docSnap.id,
+        name: docSnap.data()?.teamName || docSnap.data()?.name || docSnap.id
+      })).sort((a, b) => a.name.localeCompare(b.name));
+      const defaultOption = '<option value="">Select team</option>';
+      teamASelect.innerHTML = defaultOption;
+      teamBSelect.innerHTML = defaultOption;
+      teamsCache.forEach(team => {
+        const optionA = document.createElement("option");
+        optionA.value = team.id;
+        optionA.textContent = team.name;
+        teamASelect.appendChild(optionA);
+        const optionB = document.createElement("option");
+        optionB.value = team.id;
+        optionB.textContent = team.name;
+        teamBSelect.appendChild(optionB);
+      });
+    }
+
+    function syncTeamName(selectEl, inputEl) {
+      const team = teamsCache.find(t => t.id === selectEl.value);
+      if (team) {
+        inputEl.value = team.name;
+      }
+    }
+
+    teamASelect.addEventListener("change", () => syncTeamName(teamASelect, teamANameInput));
+    teamBSelect.addEventListener("change", () => syncTeamName(teamBSelect, teamBNameInput));
+
+    async function setActivePoll(pollId) {
+      const snap = await getDocs(pollsRef);
+      if (snap.empty) return;
+      const batch = writeBatch(db);
+      snap.forEach(docSnap => {
+        const isTarget = docSnap.id === pollId;
+        const updateData = {
+          isActive: isTarget,
+          updatedAt: serverTimestamp()
+        };
+        if (isTarget) {
+          updateData.activatedAt = serverTimestamp();
+        }
+        batch.update(docSnap.ref, updateData);
+      });
+      await batch.commit();
+    }
+
+    async function clearActivePolls() {
+      const snap = await getDocs(pollsRef);
+      if (snap.empty) return;
+      const batch = writeBatch(db);
+      let changed = false;
+      snap.forEach(docSnap => {
+        if (docSnap.data()?.isActive) {
+          changed = true;
+          batch.update(docSnap.ref, {
+            isActive: false,
+            updatedAt: serverTimestamp()
+          });
+        }
+      });
+      if (changed) {
+        await batch.commit();
+      }
+    }
+
+    async function deletePollWithVotes(pollId) {
+      const votesRef = collection(db, "matchVotes", pollId, "votes");
+      try {
+        const votesSnap = await getDocs(votesRef);
+        const deletions = votesSnap.docs.map(docSnap => deleteDoc(docSnap.ref));
+        if (deletions.length) {
+          await Promise.allSettled(deletions);
+        }
+      } catch (err) {
+        console.error("Failed to delete poll votes", err);
+      }
+      await deleteDoc(doc(db, "matchPolls", pollId));
+    }
+
+    function renderPolls(docs) {
+      pollsList.innerHTML = "";
+      if (!docs.length) {
+        pollsList.innerHTML = '<p class="text-gray-300 text-sm">No polls saved yet. Use the form above to create one.</p>';
+        clearActiveBtn.disabled = true;
+        return;
+      }
+
+      const polls = docs.map(docSnap => ({
+        id: docSnap.id,
+        ...docSnap.data()
+      }));
+
+      polls.sort((a, b) => {
+        if (a.isActive && !b.isActive) return -1;
+        if (!a.isActive && b.isActive) return 1;
+        const aDate = coerceDate(a.scheduledAt) || coerceDate(a.createdAt);
+        const bDate = coerceDate(b.scheduledAt) || coerceDate(b.createdAt);
+        if (aDate && bDate) return bDate - aDate;
+        if (aDate) return -1;
+        if (bDate) return 1;
+        return a.title?.localeCompare(b.title || "") || 0;
+      });
+
+      clearActiveBtn.disabled = !polls.some(p => p.isActive);
+
+      polls.forEach(poll => {
+        const card = document.createElement("div");
+        card.className = "bg-gray-800 border border-gray-700 rounded-lg p-4 flex flex-col md:flex-row md:items-start md:justify-between gap-4";
+
+        const scheduledText = formatDateTime(poll.scheduledAt) || "TBD";
+        const voteKey = poll.voteId || poll.id;
+        const matchReference = poll.matchId ? `Match ID: ${escapeHtml(poll.matchId)}` : "";
+
+        card.innerHTML = `
+          <div>
+            <div class="flex items-center gap-2 flex-wrap">
+              <h3 class="text-xl font-semibold">${escapeHtml(poll.title || "Who will win?")}</h3>
+              ${poll.isActive ? '<span class="px-2 py-0.5 text-xs rounded bg-green-600">Active</span>' : ""}
+            </div>
+            <p class="text-sm text-gray-300 mt-1">${escapeHtml(poll.teamAName || "Team A")} vs ${escapeHtml(poll.teamBName || "Team B")}</p>
+            <p class="text-xs text-gray-400 mt-1">Scheduled: ${escapeHtml(scheduledText)}${matchReference ? ` • ${matchReference}` : ""}</p>
+            <p class="text-xs text-gray-500 mt-1">Vote key: ${escapeHtml(voteKey)}</p>
+          </div>
+          <div class="flex flex-col gap-2 items-start md:items-end">
+            <button data-action="set-active" data-id="${poll.id}" class="px-3 py-1 bg-indigo-600 hover:bg-indigo-700 rounded text-sm ${poll.isActive ? 'opacity-50 cursor-not-allowed' : ''}" ${poll.isActive ? 'disabled' : ''}>Set Active</button>
+            <button data-action="edit" data-id="${poll.id}" class="px-3 py-1 bg-yellow-600 hover:bg-yellow-700 rounded text-sm">Edit</button>
+            <button data-action="delete" data-id="${poll.id}" class="px-3 py-1 bg-red-600 hover:bg-red-700 rounded text-sm">Delete</button>
+          </div>
+        `;
+
+        pollsList.appendChild(card);
+      });
+
+      pollsList.querySelectorAll('[data-action="set-active"]').forEach(btn => {
+        btn.addEventListener("click", async event => {
+          const id = event.currentTarget.dataset.id;
+          if (!id) return;
+          try {
+            await setActivePoll(id);
+            alert("Active poll updated.");
+          } catch (err) {
+            console.error("Failed to activate poll", err);
+            alert("Unable to update the active poll. Please try again.");
+          }
+        });
+      });
+
+      pollsList.querySelectorAll('[data-action="edit"]').forEach(btn => {
+        btn.addEventListener("click", event => {
+          const id = event.currentTarget.dataset.id;
+          const poll = polls.find(p => p.id === id);
+          if (!poll) return;
+          pollForm.dataset.editId = poll.id;
+          pollSubmitBtn.textContent = "Update Poll";
+          pollCancelBtn.classList.remove("hidden");
+          pollTitleInput.value = poll.title || "";
+          teamASelect.value = poll.teamAId || "";
+          teamBSelect.value = poll.teamBId || "";
+          teamANameInput.value = poll.teamAName || "";
+          teamBNameInput.value = poll.teamBName || "";
+          voteIdInput.value = poll.voteId || "";
+          matchIdInput.value = poll.matchId || "";
+          scheduledAtInput.value = toInputValue(poll.scheduledAt);
+          setActiveInput.checked = Boolean(poll.isActive);
+          window.scrollTo({ top: pollForm.offsetTop - 80, behavior: "smooth" });
+        });
+      });
+
+      pollsList.querySelectorAll('[data-action="delete"]').forEach(btn => {
+        btn.addEventListener("click", async event => {
+          const id = event.currentTarget.dataset.id;
+          if (!id) return;
+          if (!confirm("Delete this poll? This will also remove its vote configuration.")) return;
+          try {
+            await deletePollWithVotes(id);
+            alert("Poll deleted.");
+          } catch (err) {
+            console.error("Failed to delete poll", err);
+            alert("Unable to delete the poll. Please try again.");
+          }
+        });
+      });
+    }
+
+    async function subscribeToPolls() {
+      if (pollsUnsub) {
+        pollsUnsub();
+        pollsUnsub = null;
+      }
+      const pollsQuery = query(pollsRef, orderBy("createdAt", "desc"));
+      pollsUnsub = onSnapshot(pollsQuery, snapshot => {
+        renderPolls(snapshot.docs);
+      }, err => {
+        console.error("Failed to load polls", err);
+        pollsList.innerHTML = '<p class="text-red-400 text-sm">Unable to load polls. Refresh the page.</p>';
+      });
+    }
+
+    loginBtn.addEventListener("click", () => {
+      const email = document.getElementById("email").value;
+      const password = document.getElementById("password").value;
+      signInWithEmailAndPassword(auth, email, password).catch(err => alert(err.message));
+    });
+
+    logoutBtn.addEventListener("click", () => signOut(auth));
+
+    pollCancelBtn.addEventListener("click", () => {
+      resetForm();
+    });
+
+    clearActiveBtn.addEventListener("click", async () => {
+      if (!confirm("Clear the active poll? The hub will hide the poll until a new one is activated.")) return;
+      try {
+        await clearActivePolls();
+        alert("Active poll cleared.");
+      } catch (err) {
+        console.error("Failed to clear active poll", err);
+        alert("Unable to clear the active poll. Please try again.");
+      }
+    });
+
+    pollForm.addEventListener("submit", async event => {
+      event.preventDefault();
+      const teamAId = teamASelect.value || null;
+      const teamBId = teamBSelect.value || null;
+      const teamAName = teamANameInput.value.trim() || teamASelect.options[teamASelect.selectedIndex]?.textContent?.trim() || "";
+      const teamBName = teamBNameInput.value.trim() || teamBSelect.options[teamBSelect.selectedIndex]?.textContent?.trim() || "";
+      if (!teamAName || !teamBName) {
+        alert("Please select or enter both team names.");
+        return;
+      }
+      if (teamAId && teamBId && teamAId === teamBId) {
+        alert("Select two different teams for the poll.");
+        return;
+      }
+
+      const title = pollTitleInput.value.trim() || "Who will win?";
+      const normalizedVoteKey = normalizeVoteKey(voteIdInput.value);
+      const finalVoteKey = normalizedVoteKey || "";
+      if (normalizedVoteKey !== voteIdInput.value.trim()) {
+        voteIdInput.value = finalVoteKey;
+      }
+
+      const matchRef = matchIdInput.value.trim() || null;
+      const scheduledValue = scheduledAtInput.value ? new Date(scheduledAtInput.value) : null;
+      const scheduledTimestamp = scheduledValue && !Number.isNaN(scheduledValue.getTime()) ? Timestamp.fromDate(scheduledValue) : null;
+      const activateAfterSave = setActiveInput.checked;
+
+      const payload = {
+        title,
+        teamAId,
+        teamAName,
+        teamBId,
+        teamBName,
+        matchId: matchRef,
+        voteId: finalVoteKey || null,
+        scheduledAt: scheduledTimestamp || null,
+        updatedAt: serverTimestamp()
+      };
+
+      const editingId = pollForm.dataset.editId;
+
+      try {
+        if (editingId) {
+          const docRef = doc(db, "matchPolls", editingId);
+          await updateDoc(docRef, payload);
+          if (!finalVoteKey) {
+            await updateDoc(docRef, {
+              voteId: editingId,
+              updatedAt: serverTimestamp()
+            });
+          }
+          if (activateAfterSave) {
+            await setActivePoll(editingId);
+          }
+          alert("Poll updated.");
+        } else {
+          const docRef = await addDoc(pollsRef, {
+            ...payload,
+            isActive: Boolean(activateAfterSave),
+            createdAt: serverTimestamp()
+          });
+          const generatedId = docRef.id;
+          if (!finalVoteKey) {
+            await updateDoc(docRef, {
+              voteId: generatedId,
+              updatedAt: serverTimestamp()
+            });
+          }
+          if (activateAfterSave) {
+            await setActivePoll(generatedId);
+          }
+          alert("Poll created.");
+        }
+        resetForm();
+      } catch (err) {
+        console.error("Failed to save poll", err);
+        alert("Unable to save the poll. Please try again.");
+      }
+    });
+
+    onAuthStateChanged(auth, async user => {
+      const isAdmin = Boolean(user && ADMIN_UIDS.includes(user.uid));
+      if (isAdmin) {
+        loginDiv.classList.add("hidden");
+        adminPanel.classList.remove("hidden");
+        await loadTeams();
+        await subscribeToPolls();
+      } else {
+        loginDiv.classList.remove("hidden");
+        adminPanel.classList.add("hidden");
+        resetForm();
+        if (pollsUnsub) {
+          pollsUnsub();
+          pollsUnsub = null;
+        }
+        pollsList.innerHTML = "";
+        if (user) {
+          alert("Access denied.");
+          signOut(auth);
+        }
+      }
+    });
+  </script>
+  <script src="./assets/include.js" defer></script>
+</body>
+</html>

--- a/firestore.rules
+++ b/firestore.rules
@@ -48,5 +48,18 @@ service cloud.firestore {
       allow read: if true;
       allow create, update, delete: if isAdmin();
     }
+
+    match /matchPolls/{pollId} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+
+    match /matchVotes/{pollId}/votes/{userId} {
+      allow read: if true;
+      allow create, update: if request.auth != null &&
+        request.auth.uid == userId &&
+        request.resource.data.team in ['A', 'B'] &&
+        request.resource.data.keys().hasOnly(['team', 'createdAt', 'updatedAt']);
+    }
   }
 }

--- a/index.html
+++ b/index.html
@@ -819,6 +819,168 @@
       z-index: 95;
     }
     .toast.visible { opacity: 1; transform: translateX(-50%) translateY(0); }
+    .is-hidden { display: none !important; }
+    .match-poll {
+      max-width: 1120px;
+      margin: 2.5rem auto 3rem;
+      padding: 0 clamp(1rem, 4vw, 1.75rem);
+    }
+    .match-poll__card {
+      position: relative;
+      border-radius: 1.5rem;
+      padding: clamp(1.75rem, 3vw, 2.4rem);
+      background: linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.82));
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      box-shadow: 0 35px 80px -45px rgba(56, 189, 248, 0.45);
+      overflow: hidden;
+      backdrop-filter: blur(18px);
+    }
+    .match-poll__card::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 12% -10%, rgba(129, 140, 248, 0.35), transparent 55%), radial-gradient(circle at 85% 0%, rgba(236, 72, 153, 0.28), transparent 60%);
+      opacity: 0.35;
+      pointer-events: none;
+      mix-blend-mode: screen;
+    }
+    .match-poll__body { position: relative; z-index: 1; display: grid; gap: 1.5rem; }
+    .match-poll__header { display: flex; flex-direction: column; gap: 0.5rem; }
+    .match-poll__heading { display: flex; flex-direction: column; gap: 0.35rem; }
+    .match-poll__eyebrow {
+      font-size: 0.75rem;
+      letter-spacing: 0.24em;
+      text-transform: uppercase;
+      color: rgba(148, 163, 184, 0.68);
+      margin: 0;
+    }
+    .match-poll__title {
+      margin: 0;
+      font-size: clamp(1.7rem, 3vw, 2.15rem);
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+    .match-poll__subhead,
+    .match-poll__meta,
+    .match-poll__status {
+      margin: 0;
+      color: rgba(226, 232, 240, 0.72);
+      font-size: 0.9rem;
+      line-height: 1.45;
+    }
+    .match-poll__status { font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: rgba(148, 163, 184, 0.9); }
+    .match-poll__content { display: grid; gap: 1.25rem; }
+    .match-poll__loading {
+      display: grid;
+      gap: 0.75rem;
+    }
+    .match-poll__loading > span {
+      display: block;
+      height: 16px;
+      border-radius: 999px;
+      background: linear-gradient(100deg, rgba(148, 163, 184, 0.08) 0%, rgba(148, 163, 184, 0.3) 50%, rgba(148, 163, 184, 0.08) 100%);
+      background-size: 200% 100%;
+      animation: poll-shimmer 1.8s ease-in-out infinite;
+    }
+    .match-poll__loading > span:nth-child(1) { width: 40%; }
+    .match-poll__loading > span:nth-child(2),
+    .match-poll__loading > span:nth-child(3) { height: 48px; border-radius: 1rem; }
+    @keyframes poll-shimmer {
+      0% { background-position: 200% 0; opacity: 0.4; }
+      50% { opacity: 0.9; }
+      100% { background-position: -200% 0; opacity: 0.4; }
+    }
+    .match-poll__options {
+      display: grid;
+      gap: 0.9rem;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      transition: opacity var(--transition-snappy);
+    }
+    .match-poll__options.is-disabled { opacity: 0.5; pointer-events: none; }
+    .match-poll__option {
+      position: relative;
+      border-radius: 1.2rem;
+      border: 1px solid rgba(99, 102, 241, 0.22);
+      background: rgba(15, 23, 42, 0.72);
+      padding: 1.05rem 1.1rem 1.05rem 1.25rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      color: var(--text-primary);
+      cursor: pointer;
+      transition: transform var(--transition-snappy), border-color var(--transition-snappy), background var(--transition-snappy), box-shadow var(--transition-snappy);
+    }
+    .match-poll__option:hover { transform: translateY(-2px); border-color: rgba(129, 140, 248, 0.5); box-shadow: 0 25px 45px -30px rgba(99, 102, 241, 0.55); }
+    .match-poll__option.is-selected {
+      border-color: rgba(56, 189, 248, 0.85);
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), rgba(99, 102, 241, 0.22));
+      box-shadow: 0 30px 55px -38px rgba(56, 189, 248, 0.75);
+    }
+    .match-poll__option.is-selected[data-team="B"] {
+      border-color: rgba(236, 72, 153, 0.9);
+      background: linear-gradient(135deg, rgba(244, 114, 182, 0.22), rgba(236, 72, 153, 0.18));
+      box-shadow: 0 30px 55px -38px rgba(244, 114, 182, 0.75);
+    }
+    .match-poll__option-label { display: flex; flex-direction: column; gap: 0.25rem; }
+    .match-poll__option-label span:first-child {
+      font-size: 0.7rem;
+      letter-spacing: 0.24em;
+      text-transform: uppercase;
+      color: rgba(148, 163, 184, 0.72);
+    }
+    .match-poll__option-label strong { font-size: 1.05rem; font-weight: 700; letter-spacing: -0.01em; }
+    .match-poll__option-count { font-size: 0.85rem; font-weight: 600; color: rgba(226, 232, 240, 0.78); white-space: nowrap; }
+    .match-poll__progress { display: grid; gap: 0.9rem; }
+    .match-poll__progress-row { display: grid; gap: 0.45rem; }
+    .match-poll__progress-meta { display: flex; justify-content: space-between; font-size: 0.7rem; letter-spacing: 0.2em; text-transform: uppercase; color: rgba(148, 163, 184, 0.7); }
+    .match-poll__progress-track {
+      position: relative;
+      height: 10px;
+      border-radius: 999px;
+      overflow: hidden;
+      background: rgba(15, 23, 42, 0.78);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+    }
+    .match-poll__progress-fill {
+      position: absolute;
+      inset: 0;
+      width: 0%;
+      border-radius: inherit;
+      transition: width 0.45s ease;
+    }
+    .match-poll__progress-fill[data-team="A"] { background: linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(56, 189, 248, 0.85)); }
+    .match-poll__progress-fill[data-team="B"] { background: linear-gradient(135deg, rgba(236, 72, 153, 0.9), rgba(244, 114, 182, 0.85)); }
+    .match-poll__empty,
+    .match-poll__error { font-size: 0.85rem; margin: 0; }
+    .match-poll__empty { color: rgba(148, 163, 184, 0.82); }
+    .match-poll__error { color: rgba(248, 113, 113, 0.9); }
+    .match-poll__login {
+      border-radius: 1.1rem;
+      border: 1px dashed rgba(148, 163, 184, 0.26);
+      background: rgba(15, 23, 42, 0.6);
+      padding: 1.1rem 1.25rem;
+      display: grid;
+      gap: 0.65rem;
+    }
+    .match-poll__login p { margin: 0; font-size: 0.9rem; color: rgba(226, 232, 240, 0.8); }
+    .match-poll__login button {
+      justify-self: flex-start;
+      border: none;
+      border-radius: 999px;
+      padding: 0.55rem 1.45rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      background: linear-gradient(135deg, rgba(129, 140, 248, 0.95), rgba(56, 189, 248, 0.95));
+      color: #020617;
+      cursor: pointer;
+      transition: transform 0.2s ease;
+      box-shadow: 0 18px 40px -25px rgba(56, 189, 248, 0.8);
+    }
+    .match-poll__login button:hover { transform: translateY(-1px); }
+    .match-poll__footer { display: flex; flex-direction: column; gap: 0.6rem; }
     @media (max-width: 1280px) {
       .hero { grid-template-columns: 1fr; }
       .control-streams { grid-template-columns: 1fr; }
@@ -827,6 +989,7 @@
     @media (max-width: 1024px) {
       .control-panel { position: static; }
       main { padding: 1.5rem 1.35rem 4rem; }
+      .match-poll { margin: 2rem auto 2.75rem; }
     }
     @media (max-width: 860px) {
       nav#global-header .header-shell { flex-direction: column; align-items: flex-start; }
@@ -838,6 +1001,9 @@
       .control-panel { padding: 1.2rem; }
       nav#global-header { padding: 0.75rem 1rem; }
       main { padding: 1.2rem 1rem 4rem; }
+      .match-poll { padding: 0 0.85rem; }
+      .match-poll__option { flex-direction: column; align-items: flex-start; gap: 0.75rem; }
+      .match-poll__option-count { align-self: flex-start; }
     }
   </style>
 </head>
@@ -869,6 +1035,72 @@
     </div>
   </nav>
   <main>
+    <section class="match-poll" data-role="match-poll" data-match-id="current">
+      <div class="match-poll__card" id="match-poll-card">
+        <div class="match-poll__body">
+          <header class="match-poll__header">
+            <div class="match-poll__heading">
+              <p class="match-poll__eyebrow">Featured Match</p>
+              <h2 class="match-poll__title" id="match-poll-title">Who will win?</h2>
+              <p class="match-poll__subhead" id="match-poll-subhead">Loading featured matchup…</p>
+              <p class="match-poll__meta is-hidden" id="match-poll-meta"></p>
+            </div>
+            <p class="match-poll__status" id="match-poll-status">Loading votes…</p>
+          </header>
+          <div class="match-poll__loading" id="match-poll-loading">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+          <div class="match-poll__content is-hidden" id="match-poll-content">
+            <div class="match-poll__login" id="match-poll-login">
+              <p>Log in with Twitch to choose your winner.</p>
+              <button type="button" id="match-poll-login-btn">Sign in to vote</button>
+            </div>
+            <div class="match-poll__options" id="match-poll-options">
+              <button type="button" class="match-poll__option" id="match-poll-option-a" data-team="A">
+                <span class="match-poll__option-label">
+                  <span>Team A</span>
+                  <strong id="match-poll-team-a-name">Team A</strong>
+                </span>
+                <span class="match-poll__option-count" id="match-poll-team-a-count">0 votes</span>
+              </button>
+              <button type="button" class="match-poll__option" id="match-poll-option-b" data-team="B">
+                <span class="match-poll__option-label">
+                  <span>Team B</span>
+                  <strong id="match-poll-team-b-name">Team B</strong>
+                </span>
+                <span class="match-poll__option-count" id="match-poll-team-b-count">0 votes</span>
+              </button>
+            </div>
+            <div class="match-poll__progress">
+              <div class="match-poll__progress-row">
+                <div class="match-poll__progress-meta">
+                  <span id="match-poll-team-a-label">Team A</span>
+                  <span id="match-poll-team-a-percent">0%</span>
+                </div>
+                <div class="match-poll__progress-track">
+                  <div class="match-poll__progress-fill" data-team="A" id="match-poll-team-a-bar"></div>
+                </div>
+              </div>
+              <div class="match-poll__progress-row">
+                <div class="match-poll__progress-meta">
+                  <span id="match-poll-team-b-label">Team B</span>
+                  <span id="match-poll-team-b-percent">0%</span>
+                </div>
+                <div class="match-poll__progress-track">
+                  <div class="match-poll__progress-fill" data-team="B" id="match-poll-team-b-bar"></div>
+                </div>
+              </div>
+            </div>
+            <div class="match-poll__footer">
+              <p class="match-poll__empty is-hidden" id="match-poll-empty">No votes yet — be the first to choose a winner!</p>
+              <p class="match-poll__error is-hidden" id="match-poll-error"></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
     <section class="hero">
       <article class="hero-card">
         <h1>All Your Tribes Streams, One Wall.</h1>
@@ -938,7 +1170,7 @@
   </main>
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
-    import { getFirestore, collection, getDocs, query, where, doc, getDoc } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
+    import { getFirestore, collection, getDocs, query, where, limit, doc, getDoc, onSnapshot, setDoc, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
 
     const firebaseConfig = {
       apiKey: "AIzaSyB_ksHlcP2P9cT5jbo2IAGxbQ4zgEODkyM",
@@ -1009,6 +1241,45 @@
         total: document.getElementById("metric-total-streams"),
         live: document.getElementById("metric-live-streams"),
         hidden: document.getElementById("metric-hidden-streams")
+      },
+      matchPoll: {
+        container: document.querySelector('[data-role="match-poll"]'),
+        card: document.getElementById("match-poll-card"),
+        loading: document.getElementById("match-poll-loading"),
+        content: document.getElementById("match-poll-content"),
+        status: document.getElementById("match-poll-status"),
+        title: document.getElementById("match-poll-title"),
+        subhead: document.getElementById("match-poll-subhead"),
+        meta: document.getElementById("match-poll-meta"),
+        login: document.getElementById("match-poll-login"),
+        loginBtn: document.getElementById("match-poll-login-btn"),
+        options: document.getElementById("match-poll-options"),
+        empty: document.getElementById("match-poll-empty"),
+        error: document.getElementById("match-poll-error"),
+        optionButtons: {
+          A: document.getElementById("match-poll-option-a"),
+          B: document.getElementById("match-poll-option-b")
+        },
+        teamNames: {
+          A: document.getElementById("match-poll-team-a-name"),
+          B: document.getElementById("match-poll-team-b-name")
+        },
+        teamCounts: {
+          A: document.getElementById("match-poll-team-a-count"),
+          B: document.getElementById("match-poll-team-b-count")
+        },
+        percentLabels: {
+          A: document.getElementById("match-poll-team-a-percent"),
+          B: document.getElementById("match-poll-team-b-percent")
+        },
+        progressLabels: {
+          A: document.getElementById("match-poll-team-a-label"),
+          B: document.getElementById("match-poll-team-b-label")
+        },
+        progressBars: {
+          A: document.getElementById("match-poll-team-a-bar"),
+          B: document.getElementById("match-poll-team-b-bar")
+        }
       }
     };
 
@@ -1026,6 +1297,451 @@
     };
 
     const teamIndex = new Map();
+
+    const pollEls = els.matchPoll || {};
+    const pollState = {
+      pollDocId: null,
+      matchId: null,
+      matchLoaded: false,
+      teams: { A: "Team A", B: "Team B" },
+      counts: { A: 0, B: 0 },
+      user: null,
+      userVote: null,
+      saving: false,
+      unsubscribe: null,
+      voteSubscriptionId: null,
+      activePollUnsubscribe: null,
+      hasError: false,
+      cleanupBound: false
+    };
+
+    function pollEnabled() {
+      return Boolean(pollEls?.container);
+    }
+
+    function setPollStatus(message) {
+      if (pollEls.status) {
+        pollEls.status.textContent = message;
+      }
+    }
+
+    function setPollLoading(isLoading) {
+      if (!pollEnabled()) return;
+      if (pollEls.loading) {
+        pollEls.loading.classList.toggle("is-hidden", !isLoading);
+      }
+      if (pollEls.content) {
+        pollEls.content.classList.toggle("is-hidden", isLoading);
+      }
+    }
+
+    function setPollError(message) {
+      if (!pollEnabled() || !pollEls.error) return;
+      pollState.hasError = Boolean(message);
+      pollEls.error.textContent = message || "";
+      pollEls.error.classList.toggle("is-hidden", !message);
+      updatePollInteractivity();
+    }
+
+    function clearPollError() {
+      setPollError("");
+    }
+
+    function formatVoteCount(value) {
+      const count = Number(value) || 0;
+      return `${count} vote${count === 1 ? "" : "s"}`;
+    }
+
+    function coerceDate(value) {
+      if (!value) return null;
+      if (value instanceof Date) return value;
+      if (typeof value?.toDate === "function") {
+        try {
+          return value.toDate();
+        } catch {
+          return null;
+        }
+      }
+      if (typeof value === "number") {
+        const numericDate = new Date(value);
+        return Number.isNaN(numericDate.getTime()) ? null : numericDate;
+      }
+      if (typeof value === "string") {
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+      }
+      return null;
+    }
+
+    function formatMatchDate(value) {
+      const date = coerceDate(value);
+      if (!date) return "";
+      try {
+        return date.toLocaleString(undefined, {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+          hour: "2-digit",
+          minute: "2-digit"
+        });
+      } catch (err) {
+        console.error("Failed to format match date", err);
+        return "";
+      }
+    }
+
+    function updatePollOptionStyles() {
+      if (!pollEnabled() || !pollEls.optionButtons) return;
+      Object.entries(pollEls.optionButtons).forEach(([teamKey, button]) => {
+        if (!button) return;
+        button.classList.toggle("is-selected", pollState.userVote === teamKey);
+      });
+    }
+
+    function updatePollInteractivity() {
+      if (!pollEnabled()) return;
+      const allowVoting = pollState.matchLoaded && !pollState.hasError && pollState.user && !pollState.saving;
+      if (pollEls.options) {
+        pollEls.options.classList.toggle("is-disabled", !allowVoting);
+      }
+      if (pollEls.optionButtons) {
+        Object.values(pollEls.optionButtons).forEach(button => {
+          if (!button) return;
+          button.disabled = !allowVoting;
+        });
+      }
+    }
+
+    function updatePollUI() {
+      if (!pollEnabled()) return;
+      const totalVotes = (pollState.counts.A || 0) + (pollState.counts.B || 0);
+      const percentA = totalVotes ? Math.round((pollState.counts.A / totalVotes) * 100) : 0;
+      const percentB = totalVotes ? 100 - percentA : 0;
+
+      if (pollEls.percentLabels) {
+        if (pollEls.percentLabels.A) pollEls.percentLabels.A.textContent = `${percentA}%`;
+        if (pollEls.percentLabels.B) pollEls.percentLabels.B.textContent = `${percentB}%`;
+      }
+      if (pollEls.progressBars) {
+        if (pollEls.progressBars.A) pollEls.progressBars.A.style.width = `${percentA}%`;
+        if (pollEls.progressBars.B) pollEls.progressBars.B.style.width = `${percentB}%`;
+      }
+      if (pollEls.teamCounts) {
+        if (pollEls.teamCounts.A) pollEls.teamCounts.A.textContent = formatVoteCount(pollState.counts.A);
+        if (pollEls.teamCounts.B) pollEls.teamCounts.B.textContent = formatVoteCount(pollState.counts.B);
+      }
+      if (pollEls.empty) {
+        pollEls.empty.classList.toggle("is-hidden", totalVotes !== 0);
+      }
+      updatePollOptionStyles();
+
+      if (!pollState.matchLoaded) {
+        setPollStatus("No featured poll is active right now.");
+        return;
+      }
+
+      let statusText = totalVotes ? `Live votes: ${totalVotes}` : "No votes cast yet.";
+      if (!pollState.user) {
+        statusText = totalVotes
+          ? `Live votes: ${totalVotes} — log in to vote.`
+          : "Log in to vote and be the first!";
+      }
+      setPollStatus(statusText);
+    }
+
+    function setPollAuthUI(isAuthenticated) {
+      if (!pollEnabled()) return;
+      if (pollEls.login) {
+        const shouldShowLogin = !isAuthenticated && pollState.matchLoaded;
+        pollEls.login.classList.toggle("is-hidden", !shouldShowLogin);
+      }
+      if (!isAuthenticated) {
+        pollState.userVote = null;
+        updatePollOptionStyles();
+      }
+      updatePollInteractivity();
+    }
+
+    function setPollSaving(isSaving) {
+      pollState.saving = Boolean(isSaving);
+      if (pollState.saving) {
+        setPollStatus("Submitting your vote…");
+      }
+      updatePollInteractivity();
+    }
+
+    async function refreshPollUserVote() {
+      if (!pollEnabled() || !pollState.user || !pollState.matchId) return;
+      try {
+        const voteSnap = await getDoc(doc(db, "matchVotes", pollState.matchId, "votes", pollState.user.id));
+        if (voteSnap.exists()) {
+          pollState.userVote = voteSnap.data()?.team ?? null;
+        } else {
+          pollState.userVote = null;
+        }
+        updatePollUI();
+      } catch (err) {
+        console.error("Failed to refresh poll vote", err);
+      }
+    }
+
+    async function ensurePollUser() {
+      if (!pollEnabled()) return null;
+      if (!window.twitchOAuth || !window.twitchOAuth.getToken()) {
+        pollState.user = null;
+        setPollAuthUI(false);
+        updatePollUI();
+        return null;
+      }
+
+      try {
+        pollState.user = await window.twitchOAuth.fetchUser();
+      } catch (err) {
+        console.error("Failed to fetch Twitch user", err);
+        pollState.user = null;
+      }
+
+      setPollAuthUI(Boolean(pollState.user));
+      if (pollState.user) {
+        await refreshPollUserVote();
+      }
+      return pollState.user;
+    }
+
+    function subscribeToPollVotes() {
+      if (!pollEnabled() || !pollState.matchId) return;
+      if (pollState.unsubscribe && pollState.voteSubscriptionId === pollState.matchId) {
+        return;
+      }
+      if (pollState.unsubscribe) {
+        pollState.unsubscribe();
+        pollState.unsubscribe = null;
+        pollState.voteSubscriptionId = null;
+      }
+      const votesRef = collection(db, "matchVotes", pollState.matchId, "votes");
+      pollState.unsubscribe = onSnapshot(votesRef, snapshot => {
+        clearPollError();
+        const counts = { A: 0, B: 0 };
+        let userVote = pollState.userVote;
+        snapshot.forEach(docSnap => {
+          const data = docSnap.data();
+          if (data?.team === "A") counts.A += 1;
+          if (data?.team === "B") counts.B += 1;
+          if (pollState.user && docSnap.id === pollState.user.id) {
+            userVote = data?.team ?? null;
+          }
+        });
+        pollState.counts = counts;
+        pollState.userVote = userVote ?? (pollState.user ? null : pollState.userVote);
+        updatePollUI();
+      }, err => {
+        console.error("Failed to subscribe to poll votes", err);
+        setPollError("Live vote updates are unavailable right now.");
+      });
+      pollState.voteSubscriptionId = pollState.matchId;
+    }
+
+    function clearActivePoll() {
+      pollState.pollDocId = null;
+      pollState.matchId = null;
+      pollState.matchLoaded = false;
+      pollState.counts = { A: 0, B: 0 };
+      pollState.teams = { A: "Team A", B: "Team B" };
+      pollState.userVote = null;
+      if (pollEls.title) {
+        pollEls.title.textContent = "Who will win?";
+      }
+      if (pollEls.teamNames) {
+        if (pollEls.teamNames.A) pollEls.teamNames.A.textContent = pollState.teams.A;
+        if (pollEls.teamNames.B) pollEls.teamNames.B.textContent = pollState.teams.B;
+      }
+      if (pollEls.progressLabels) {
+        if (pollEls.progressLabels.A) pollEls.progressLabels.A.textContent = pollState.teams.A;
+        if (pollEls.progressLabels.B) pollEls.progressLabels.B.textContent = pollState.teams.B;
+      }
+      if (pollEls.subhead) {
+        pollEls.subhead.textContent = "Awaiting the next matchup.";
+      }
+      if (pollEls.meta) {
+        pollEls.meta.textContent = "";
+        pollEls.meta.classList.add("is-hidden");
+      }
+      if (pollEls.empty) {
+        pollEls.empty.classList.add("is-hidden");
+      }
+      if (pollState.unsubscribe) {
+        pollState.unsubscribe();
+        pollState.unsubscribe = null;
+      }
+      pollState.voteSubscriptionId = null;
+      updatePollInteractivity();
+      updatePollUI();
+      setPollAuthUI(Boolean(pollState.user));
+    }
+
+    function applyActivePollDoc(docSnap) {
+      if (!pollEnabled()) return;
+      if (!docSnap) {
+        clearActivePoll();
+        setPollLoading(false);
+        return;
+      }
+
+      const data = docSnap.data() || {};
+      const voteIdCandidate = (data.voteId || docSnap.id || "").trim();
+      const nextVoteId = voteIdCandidate || docSnap.id;
+      const voteIdChanged = pollState.matchId !== nextVoteId;
+
+      pollState.pollDocId = docSnap.id;
+      pollState.matchId = nextVoteId;
+      pollState.matchLoaded = true;
+      pollState.teams = {
+        A: data.teamAName || data.teamA || data.team1 || "Team A",
+        B: data.teamBName || data.teamB || data.team2 || "Team B"
+      };
+      pollState.counts = { A: 0, B: 0 };
+      pollState.userVote = null;
+
+      if (pollEls.title) {
+        pollEls.title.textContent = (data.title || "Who will win?").trim() || "Who will win?";
+      }
+      if (pollEls.teamNames) {
+        if (pollEls.teamNames.A) pollEls.teamNames.A.textContent = pollState.teams.A;
+        if (pollEls.teamNames.B) pollEls.teamNames.B.textContent = pollState.teams.B;
+      }
+      if (pollEls.progressLabels) {
+        if (pollEls.progressLabels.A) pollEls.progressLabels.A.textContent = pollState.teams.A;
+        if (pollEls.progressLabels.B) pollEls.progressLabels.B.textContent = pollState.teams.B;
+      }
+      if (pollEls.subhead) {
+        pollEls.subhead.textContent = `${pollState.teams.A} vs ${pollState.teams.B}`;
+      }
+
+      const metaParts = [];
+      const scheduledAt = formatMatchDate(data.scheduledAt ?? data.scheduled ?? data.startTime ?? data.matchTime ?? "");
+      if (scheduledAt) metaParts.push(scheduledAt);
+      if (data.matchId) metaParts.push(`Match ID: ${data.matchId}`);
+      if (data.voteId && data.voteId !== docSnap.id) metaParts.push(`Vote Key: ${data.voteId}`);
+      if (pollEls.meta) {
+        pollEls.meta.textContent = metaParts.join(" • ");
+        pollEls.meta.classList.toggle("is-hidden", metaParts.length === 0);
+      }
+
+      clearPollError();
+      setPollLoading(false);
+      updatePollInteractivity();
+      updatePollUI();
+      setPollAuthUI(Boolean(pollState.user));
+
+      if (voteIdChanged && pollState.unsubscribe) {
+        pollState.unsubscribe();
+        pollState.unsubscribe = null;
+        pollState.voteSubscriptionId = null;
+      }
+      subscribeToPollVotes();
+      if (pollState.user) {
+        refreshPollUserVote();
+      }
+    }
+
+    function subscribeToActivePoll() {
+      if (!pollEnabled()) return;
+      if (pollState.activePollUnsubscribe) {
+        pollState.activePollUnsubscribe();
+        pollState.activePollUnsubscribe = null;
+      }
+      const pollsRef = collection(db, "matchPolls");
+      const activeQuery = query(pollsRef, where("isActive", "==", true), limit(1));
+      pollState.activePollUnsubscribe = onSnapshot(activeQuery, snapshot => {
+        clearPollError();
+        if (snapshot.empty) {
+          applyActivePollDoc(null);
+        } else {
+          applyActivePollDoc(snapshot.docs[0]);
+        }
+      }, err => {
+        console.error("Failed to subscribe to featured poll", err);
+        setPollError("Unable to load the featured poll right now.");
+        applyActivePollDoc(null);
+        setPollLoading(false);
+      });
+    }
+
+    async function submitPollVote(teamKey) {
+      if (!pollEnabled() || !pollState.matchLoaded || !pollState.matchId) return;
+      if (!pollState.user) {
+        setPollAuthUI(false);
+        return;
+      }
+      if (pollState.saving || teamKey === pollState.userVote) {
+        return;
+      }
+
+      clearPollError();
+      setPollSaving(true);
+      try {
+        const voteRef = doc(db, "matchVotes", pollState.matchId, "votes", pollState.user.id);
+        const payload = { team: teamKey };
+        if (pollState.userVote) {
+          payload.updatedAt = serverTimestamp();
+        } else {
+          payload.createdAt = serverTimestamp();
+        }
+        await setDoc(voteRef, payload, { merge: true });
+        pollState.userVote = teamKey;
+        updatePollOptionStyles();
+        setPollStatus("Vote saved!");
+      } catch (err) {
+        console.error("Failed to submit poll vote", err);
+        setPollError("Unable to save your vote. Please try again.");
+      } finally {
+        setPollSaving(false);
+      }
+    }
+
+    function bindPollEvents() {
+      if (!pollEnabled()) return;
+      if (pollEls.optionButtons?.A) {
+        pollEls.optionButtons.A.addEventListener("click", () => submitPollVote("A"));
+      }
+      if (pollEls.optionButtons?.B) {
+        pollEls.optionButtons.B.addEventListener("click", () => submitPollVote("B"));
+      }
+      if (pollEls.loginBtn) {
+        pollEls.loginBtn.addEventListener("click", () => {
+          if (window.twitchOAuth) {
+            window.twitchOAuth.login();
+          }
+        });
+      }
+      if (!pollState.cleanupBound) {
+        window.addEventListener("beforeunload", () => {
+          if (pollState.unsubscribe) {
+            pollState.unsubscribe();
+            pollState.unsubscribe = null;
+          }
+          if (pollState.activePollUnsubscribe) {
+            pollState.activePollUnsubscribe();
+            pollState.activePollUnsubscribe = null;
+          }
+        });
+        pollState.cleanupBound = true;
+      }
+    }
+
+    async function initializeMatchPoll() {
+      if (!pollEnabled()) return;
+      bindPollEvents();
+      setPollLoading(true);
+      setPollStatus("Loading featured poll…");
+      await ensurePollUser();
+      subscribeToActivePoll();
+      window.addEventListener("storage", event => {
+        if (event.key === "twitch_token") {
+          ensurePollUser();
+        }
+      });
+    }
 
     const parentHosts = new Set([
       window.location.hostname,
@@ -1935,6 +2651,7 @@ function toNumber(value, fallback = 0) {
       hydrateTeamIndex();
       initializeState();
       bindEvents();
+      await initializeMatchPoll();
       renderAll();
       loadStreamerDirectory();
       updateLiveChannels();


### PR DESCRIPTION
## Summary
- open read access to matchPolls so the hub can load the featured matchup configuration
- allow authenticated users to create or update their own vote documents in matchVotes with a validated team choice

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68dddeedd9c0832a93c721dd14c8e9a4